### PR TITLE
Encrypted seshat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,13 @@ before_install:
     choco install sqlite;
     cd C:\ProgramData\chocolatey\lib\SQLite\tools;
     lib /def:sqlite3.def /out:sqlite3.lib;
+    elif [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then
+    HOMEBREW_NO_AUTO_UPDATE=1 brew install sqlcipher;
+    nvm install $TRAVIS_NODE_VERSION;
+    nvm use ${TRAVIS_NODE_VERSION};
     else
+    sudo apt-get update -q;
+    sudo apt-get install libsqlcipher-dev -y;
     nvm install $TRAVIS_NODE_VERSION;
     nvm use ${TRAVIS_NODE_VERSION};
     fi
@@ -36,7 +42,7 @@ before_install:
   - npm i -g yarn@latest neon-cli@latest
 
 script:
-  - cargo test
+  - cargo test -- --test-threads=1
   - cd seshat-node
   - yarn install
   - yarn test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ matrix:
     - os: windows
   include:
     - os: linux
+      dist: bionic
       language: rust
       env:
         - TRAVIS_NODE_VERSION="12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,11 +9,12 @@ description = "A matrix message logger with full text search support"
 [dependencies]
 tantivy = { git = "https://github.com/tantivy-search/tantivy", rev = "2f867aa" }
 tinysegmenter = "0.1"
-rusqlite = "0.20"
+rusqlite = { version = "0.20", features = ["sqlcipher"] }
 fs_extra = "1.1.0"
 r2d2_sqlite = "0.12"
 r2d2 = "0.8"
 failure = "0.1.5"
+zeroize = "1.0.0"
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,8 @@ fs_extra = "1.1.0"
 r2d2_sqlite = "0.12"
 r2d2 = "0.8"
 failure = "0.1.5"
+rust-crypto = "0.2.36"
+rand = "0.7.2"
 zeroize = "1.0.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ failure = "0.1.5"
 rust-crypto = "0.2.36"
 rand = "0.7.2"
 zeroize = "1.0.0"
+byteorder = "1.3.2"
 
 [dev-dependencies]
 tempfile = "3.1"

--- a/seshat-node/lib/index.js
+++ b/seshat-node/lib/index.js
@@ -71,6 +71,9 @@ const seshat = require('../native');
  * database already exist in the given folder the database will be reused.
  * @param  {string} config.language The language that the database should use
  * for indexing. Picking the correct indexing language may improve the search.
+ * @param  {string} config.passphrase The passphrase that should be used to
+ * encrypt the database. The database is left unencrypted it no passphrase is
+ * set.
  *
  * @constructor
  *

--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -21,4 +21,4 @@ serde_json = "1.0"
 r2d2 = "0.8"
 r2d2_sqlite = "0.12"
 neon-serde = "=0.2.0"
-seshat = { git = "https://github.com/matrix-org/seshat/", rev = "8e50ac7" }
+seshat = { path = "../../" }

--- a/seshat-node/native/src/lib.rs
+++ b/seshat-node/native/src/lib.rs
@@ -264,8 +264,15 @@ declare_types! {
                             Language::Unknown => return cx.throw_type_error(
                                 format!("Unsuported language: {}", l.value())
                             ),
-                            _ => {config.set_language(&language);}
+                            _ => {config = config.set_language(&language);}
                         }
+                    }
+                }
+
+                if let Ok(p) = c.get(&mut cx, "passphrase") {
+                    if let Ok(p) = p.downcast::<JsString>() {
+                        let passphrase: String = p.value();
+                        config = config.set_passphrase(passphrase);
                     }
                 }
             }

--- a/seshat-node/test/test.js
+++ b/seshat-node/test/test.js
@@ -340,6 +340,19 @@ describe('Database', function() {
         assert(!await db.isEmpty());
     });
 
+    it('should allow us to create an encrypted db', async function() {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seshat-'));
+        let db = new Seshat(tempDir, {passphrase: "wordpass"});
+
+        assert(await db.isEmpty());
+        db.addEvent(matrixEvent, matrixProfileOnlyDisplayName);
+        await db.commit();
+        assert(!await db.isEmpty());
+
+        expect(() => db = new Seshat(tempDir)).to.throw('');
+    });
+
+
     it('should throw an error when adding events with missing fields.', function() {
         delete matrixEvent.content;
         expect(() => db.addEvent(matrixEvent, matrixProfile)).to.throw('Event doesn\'t contain any content');

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use zeroize::Zeroizing;
+
 use crate::events::{EventType, RoomId};
 
 #[derive(Debug, PartialEq, Clone)]
@@ -206,6 +208,7 @@ impl From<&str> for Language {
 /// Configuration for the seshat database.
 pub struct Config {
     pub(crate) language: Language,
+    pub(crate) passphrase: Option<Zeroizing<String>>,
 }
 
 impl Config {
@@ -223,12 +226,22 @@ impl Config {
         self.language = language.clone();
         self
     }
+
+    /// Set the passphrase of the database.
+    /// # Arguments
+    ///
+    /// * `passphrase` - The passphrase of the database.
+    pub fn set_passphrase<P: Into<String>>(mut self, passphrase: P) -> Self {
+        self.passphrase = Some(Zeroizing::new(passphrase.into()));
+        self
+    }
 }
 
 impl Default for Config {
     fn default() -> Config {
         Config {
             language: Language::Unknown,
+            passphrase: None,
         }
     }
 }

--- a/src/database.rs
+++ b/src/database.rs
@@ -460,14 +460,12 @@ impl Database {
 
     fn get_version(connection: &rusqlite::Connection) -> Result<i64> {
         connection.execute(
-            "INSERT OR IGNORE INTO seshat_version ( version ) VALUES(?1)",
+            "INSERT OR IGNORE INTO version ( version ) VALUES(?1)",
             &[DATABASE_VERSION],
         )?;
 
         let version: i64 =
-            connection.query_row("SELECT version FROM seshat_version", NO_PARAMS, |row| {
-                row.get(0)
-            })?;
+            connection.query_row("SELECT version FROM version", NO_PARAMS, |row| row.get(0))?;
 
         // Do database migrations here before bumping the database version.
 
@@ -516,7 +514,7 @@ impl Database {
         )?;
 
         conn.execute(
-            "CREATE TABLE IF NOT EXISTS seshat_version (
+            "CREATE TABLE IF NOT EXISTS version (
                 id INTEGER NOT NULL PRIMARY KEY CHECK (id = 1),
                 version INTEGER NOT NULL
             )",

--- a/src/database.rs
+++ b/src/database.rs
@@ -254,7 +254,8 @@ impl Database {
     /// current one.
     pub fn change_passphrase(self, new_passphrase: &str) -> Result<()> {
         match self.passphrase {
-            Some(_p) => {
+            Some(p) => {
+                Index::change_passphrase(&self.path, &p, new_passphrase)?;
                 self.connection
                     .pragma_update(None, "rekey", &new_passphrase as &dyn ToSql)?;
             }
@@ -298,7 +299,7 @@ impl Database {
     }
 
     fn create_index<P: AsRef<Path>>(path: &P, config: &Config) -> Result<Index> {
-        Ok(Index::new(path, &config.language)?)
+        Ok(Index::new(path, &config)?)
     }
 
     fn write_events_helper(

--- a/src/encrypted_dir.rs
+++ b/src/encrypted_dir.rs
@@ -97,7 +97,7 @@ impl EncryptedMmapDirectory {
         // Expand the store key into a encryption and MAC key.
         let (encryption_key, mac_key) = EncryptedMmapDirectory::expand_store_key(&store_key);
 
-        // Open our underlying bare tantivy mmap based directory.
+        // Open our underlying bare Tantivy mmap based directory.
         let mmap_dir = tantivy::directory::MmapDirectory::open(&path)?;
 
         Ok(EncryptedMmapDirectory {
@@ -278,7 +278,7 @@ impl EncryptedMmapDirectory {
             return Err(IoError::new(ErrorKind::Other, "invalid index store version").into());
         }
 
-        // Rederive our key using the passphrase and salt.
+        // Re-derive our key using the passphrase and salt.
         let (key, hmac_key) = EncryptedMmapDirectory::rederive_key(passphrase, &salt, pbkdf_count);
 
         // First check our MAC of the encrypted key.
@@ -361,7 +361,7 @@ impl EncryptedMmapDirectory {
         // Derive a AES key from our passphrase using a randomly generated salt
         // to prevent bruteforce attempts using rainbow tables.
         let (key, hmac_key, salt) = EncryptedMmapDirectory::derive_key(passphrase, pbkdf_count)?;
-        // Generate a new random store key. This key will encrypt our tantivy
+        // Generate a new random store key. This key will encrypt our Tantivy
         // indexing files. The key itself is stored encrypted using the derived
         // key.
         let store_key = EncryptedMmapDirectory::generate_key()?;
@@ -574,7 +574,7 @@ impl Directory for EncryptedMmapDirectory {
     }
 }
 
-// This tantivy trait is used to indicate when no more writes are expected to be
+// This Tantivy trait is used to indicate when no more writes are expected to be
 // done on a writer.
 impl<E: crypto::symmetriccipher::BlockEncryptor, M: Mac, W: Write> TerminatingWrite
     for AesWriter<E, M, W>

--- a/src/encrypted_dir.rs
+++ b/src/encrypted_dir.rs
@@ -91,7 +91,9 @@ pub(crate) const PBKDF_COUNT: u32 = 10_000;
 /// derived with the user provided passphrase using [PBKDF2][pbkdf]. We generate
 /// a random 128 bit salt and derive a 512 bit key using PBKDF2:
 ///
+/// ```text
 ///     derived_key = PBKDF2(SHA512, passphrase, salt, count, 512)
+/// ```
 ///
 /// After key derivation, the key is split into a 256 bit AES encryption key and
 /// a 256 bit MAC key.
@@ -100,24 +102,32 @@ pub(crate) const PBKDF_COUNT: u32 = 10_000;
 /// was derived before, a random IV will be generated before encrypting the
 /// store_key:
 ///
+/// ```text
 ///     ciphertext = AES256-CTR(iv, store_key)
+/// ```
 ///
 /// A MAC of the encrypted ciphertext will be created using
 /// the derived MAC key and [HMAC-SHA256][hmac]:
 ///
+/// ```text
 ///     mac = HMAC-SHA256(mac_key, version || iv || salt || ciphertext)
+/// ```
 ///
 /// The store key will be written to a file concatenated with a store version,
 /// IV, salt, PBKDF count, and MAC. The PBKDF count will be stored using the big
 /// endian byte order:
 ///
+/// ```text
 ///     key_file = (version || iv || salt || pbkdf_count || mac || key_ciphertext)
+/// ```
 ///
 /// Our store key will be used to encrypt the many files that Tantivy generates.
 /// For this, the store key will be expanded into an 256 bit encryption key and
 /// a 256 bit MAC key using [HKDF][hkdf].
 ///
+/// ```text
 ///     encryption_key, mac_key = HKDF(SHA512, store_key, "", 512)
+/// ```
 ///
 /// Those two keys are used to encrypt and authenticate the Tantivy files. The
 /// encryption scheme is similar to the one used for the store key, AES-CTR mode
@@ -126,12 +136,16 @@ pub(crate) const PBKDF_COUNT: u32 = 10_000;
 ///
 /// The MAC will be calculated only on the ciphertext:
 ///
+/// ```text
 ///     mac = HMAC-SHA256(mac_key, ciphertext)
+/// ```
 ///
 /// The file format differs a bit, the MAC will be at the end of the file and
 /// the ciphertext is between the IV and salt:
 ///
+/// ```text
 ///     file_data = (iv || ciphertext || mac)
+/// ```
 ///
 /// [aes]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
 /// [pbkdf]: https://en.wikipedia.org/wiki/PBKDF2

--- a/src/encrypted_dir.rs
+++ b/src/encrypted_dir.rs
@@ -83,8 +83,60 @@ pub(crate) const PBKDF_COUNT: u32 = 10;
 pub(crate) const PBKDF_COUNT: u32 = 10_000;
 
 #[derive(Clone, Debug)]
-/// A Directory implementation that wraps a MmapDirectory and adds AES based
-/// encryption to the file read/write operations.
+/// A Directory implementation that wraps a MmapDirectory and adds [AES][aes]
+/// based encryption to the file read/write operations.
+///
+/// When a new EncryptedMmapDirectory is created a random 256 bit AES key is
+/// generated, the store key. This key is encrypted using a key that will be
+/// derived with the user provided passphrase using [PBKDF2][pbkdf]. We generate
+/// a random 128 bit salt and derive a 512 bit key using PBKDF2:
+///
+///     derived_key = PBKDF2(SHA512, passphrase, salt, count, 512)
+///
+/// After key derivation, the key is split into a 256 bit AES encryption key and
+/// a 256 bit MAC key.
+///
+/// The store key will be encrypted using AES-CTR with the encryption key that
+/// was derived before, a random IV will be generated before encrypting the
+/// store_key:
+///
+///     ciphertext = AES256-CTR(iv, store_key)
+///
+/// A MAC of the encrypted ciphertext will be created using
+/// the derived MAC key and [HMAC-SHA256][hmac]:
+///
+///     mac = HMAC-SHA256(mac_key, version || iv || salt || ciphertext)
+///
+/// The store key will be written to a file concatenated with a store version,
+/// IV, salt, PBKDF count, and MAC. The PBKDF count will be stored using the big
+/// endian byte order:
+///
+///     key_file = (version || iv || salt || pbkdf_count || mac || key_ciphertext)
+///
+/// Our store key will be used to encrypt the many files that Tantivy generates.
+/// For this, the store key will be expanded into an 256 bit encryption key and
+/// a 256 bit MAC key using [HKDF][hkdf].
+///
+///     encryption_key, mac_key = HKDF(SHA512, store_key, "", 512)
+///
+/// Those two keys are used to encrypt and authenticate the Tantivy files. The
+/// encryption scheme is similar to the one used for the store key, AES-CTR mode
+/// for encryption and HMAC-SHA256 for authentication. For every encrypted file
+/// a new random 128 bit IV will be generated.
+///
+/// The MAC will be calculated only on the ciphertext:
+///
+///     mac = HMAC-SHA256(mac_key, ciphertext)
+///
+/// The file format differs a bit, the MAC will be at the end of the file and
+/// the ciphertext is between the IV and salt:
+///
+///     file_data = (iv || ciphertext || mac)
+///
+/// [aes]: https://en.wikipedia.org/wiki/Advanced_Encryption_Standard
+/// [pbkdf]: https://en.wikipedia.org/wiki/PBKDF2
+/// [hkdf]: https://en.wikipedia.org/wiki/HKDF
+/// [hmac]: https://en.wikipedia.org/wiki/HMAC
 pub struct EncryptedMmapDirectory {
     path: PathBuf,
     mmap_dir: tantivy::directory::MmapDirectory,

--- a/src/encrypted_dir.rs
+++ b/src/encrypted_dir.rs
@@ -1,0 +1,552 @@
+// Copyright 2019 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+use rand::{thread_rng, Rng};
+use std::fs::File;
+use std::io::Error as IoError;
+use std::io::{BufWriter, Cursor, ErrorKind, Read, Write};
+use std::path::{Path, PathBuf};
+
+use crypto::aessafe::AesSafe256Encryptor;
+use crypto::blockmodes::CtrMode;
+use crypto::buffer::{BufferResult, ReadBuffer, RefReadBuffer, RefWriteBuffer, WriteBuffer};
+use crypto::hkdf::hkdf_expand;
+use crypto::hmac::Hmac;
+use crypto::mac::{Mac, MacResult};
+use crypto::pbkdf2::pbkdf2;
+use crypto::sha2::{Sha256, Sha512};
+use crypto::symmetriccipher::{Decryptor, Encryptor};
+
+use tantivy::directory::error::IOError as TvIoError;
+use tantivy::directory::error::{
+    DeleteError, LockError, OpenDirectoryError, OpenReadError, OpenWriteError,
+};
+use tantivy::directory::Directory;
+use tantivy::directory::WatchHandle;
+use tantivy::directory::{
+    AntiCallToken, DirectoryLock, Lock, ReadOnlySource, TerminatingWrite, WatchCallback, WritePtr,
+};
+
+use zeroize::Zeroizing;
+
+use crate::encrypted_stream::{AesReader, AesWriter};
+
+/// KeyBuffer type that makes sure that the buffer is zeroed out before being
+/// dropped.
+type KeyBuffer = Zeroizing<Vec<u8>>;
+
+/// Key derivation result type for our initial key derivation. Consists of a
+/// tuple containing a encryption key, a MAC key, and a random salt.
+type InitialKeyDerivationResult = (KeyBuffer, KeyBuffer, Vec<u8>);
+
+/// Key derivation result for our subsequent key derivations. The salt will be
+/// read from our key file and we will re-derive our encryption and MAC keys.
+type KeyDerivationResult = (KeyBuffer, KeyBuffer);
+
+// The constants here are chosen to be similar to the constants for the Matrix
+// key export format[1].
+// [1] https://matrix.org/docs/spec/client_server/r0.5.0#key-exports
+const KEYFILE: &str = "seshat-index.key";
+// 16 byte random salt.
+const SALT_SIZE: usize = 16;
+// 16 byte random IV for the AES-CTR mode.
+const IV_SIZE: usize = 16;
+// 32 byte or 256 bit encryption keys.
+const KEY_SIZE: usize = 32;
+// 32 byte message authentication code since HMAC-SHA256 is used.
+const MAC_LENGTH: usize = 32;
+// 1 byte for the store version.
+const VERSION: u8 = 1;
+
+#[cfg(test)]
+// Tests don't need to protect against brute force attacks.
+const PBKDF_COUNT: u32 = 10;
+
+#[cfg(not(test))]
+// This is quite a bit lower than the spec since the encrypted key and index
+// will not be public. An attacker would need to get hold of the encrypted index,
+// its key and only then move on to bruteforcing the key. Even if the attacker
+// decrypts the index he wouldn't get to the events itself, only to the index
+// of them.
+const PBKDF_COUNT: u32 = 10_000;
+
+#[derive(Clone, Debug)]
+/// A Directory implementation that wraps a MmapDirectory and adds AES based
+/// encryption to the file read/write operations.
+pub struct EncryptedMmapDirectory {
+    path: PathBuf,
+    mmap_dir: tantivy::directory::MmapDirectory,
+    encryption_key: KeyBuffer,
+    mac_key: KeyBuffer,
+}
+
+impl EncryptedMmapDirectory {
+    /// Open a encrypted mmap directory. If the directory is empty a new
+    /// directory key will be generated and encrypted with the given passphrase.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path where the directory should reside in.
+    /// * `passphrase` - The passphrase.
+    ///
+    /// Returns an error if the path does not exist, if it is not a directory or
+    /// if there was an error when trying to decrypt the directory key e.g. the
+    /// given passphrase was incorrect.
+    pub fn open<P: AsRef<Path>>(path: P, passphrase: &str) -> Result<Self, OpenDirectoryError> {
+        if passphrase.is_empty() {
+            return Err(IoError::new(ErrorKind::Other, "empty passphrase").into());
+        }
+
+        let path = PathBuf::from(path.as_ref());
+        let key_path = path.as_path().join(KEYFILE);
+
+        let key_file = File::open(&key_path);
+
+        // Either load a store key or create a new store key if the key file
+        // doesn't exist.
+        let store_key = match key_file {
+            Ok(k) => EncryptedMmapDirectory::load_store_key(k, passphrase)?,
+            Err(e) => {
+                if e.kind() != ErrorKind::NotFound {
+                    return Err(e.into());
+                }
+                EncryptedMmapDirectory::create_new_store(&key_path, passphrase)?
+            }
+        };
+
+        // Expand the store key into a encryption and MAC key.
+        let (encryption_key, mac_key) = EncryptedMmapDirectory::expand_store_key(&store_key);
+
+        // Open our underlying bare tantivy mmap based directory.
+        let mmap_dir = tantivy::directory::MmapDirectory::open(&path)?;
+
+        Ok(EncryptedMmapDirectory {
+            path,
+            mmap_dir,
+            encryption_key,
+            mac_key,
+        })
+    }
+
+    /// Change the passphrase that is used to encrypt the store key.
+    /// This will decrypt and re-encrypt the store key using the new passphrase.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - The path where the directory resides in.
+    /// * `old_passphrase` - The currently used passphrase.
+    /// * `new_passphrase` - The passphrase that should be used from now on.
+    pub fn change_passphrase<P: AsRef<Path>>(
+        path: P,
+        old_passphrase: &str,
+        new_passphrase: &str,
+    ) -> Result<(), OpenDirectoryError> {
+        if old_passphrase.is_empty() || new_passphrase.is_empty() {
+            return Err(IoError::new(ErrorKind::Other, "empty passphrase").into());
+        }
+
+        let key_path = path.as_ref().join(KEYFILE);
+        let key_file = File::open(&key_path)?;
+
+        // Load our store key using the old passphrase.
+        let store_key = EncryptedMmapDirectory::load_store_key(key_file, old_passphrase)?;
+        // Derive new encryption keys using the new passphrase.
+        let (key, hmac_key, salt) = EncryptedMmapDirectory::derive_key(new_passphrase)?;
+        // Re-encrypt our store key using the newly derived keys.
+        EncryptedMmapDirectory::encrypt_store_key(&key, &salt, &hmac_key, &store_key, &key_path)?;
+
+        Ok(())
+    }
+
+    /// Expand the given store key into an encryption key and HMAC key.
+    fn expand_store_key(store_key: &[u8]) -> (KeyBuffer, KeyBuffer) {
+        let mut hkdf_result = Zeroizing::new([0u8; KEY_SIZE * 2]);
+
+        hkdf_expand(Sha512::new(), &store_key, &[], &mut *hkdf_result);
+        let (key, hmac_key) = hkdf_result.split_at(KEY_SIZE);
+        (
+            Zeroizing::new(Vec::from(key)),
+            Zeroizing::new(Vec::from(hmac_key)),
+        )
+    }
+
+    /// Load a store key from the given file and decrypt it using the given
+    /// passphrase.
+    fn load_store_key(
+        mut key_file: File,
+        passphrase: &str,
+    ) -> Result<KeyBuffer, OpenDirectoryError> {
+        let mut iv = [0u8; IV_SIZE];
+        let mut salt = [0u8; SALT_SIZE];
+        let mut expected_mac = [0u8; MAC_LENGTH];
+        let mut version = [0u8; 1];
+        let mut encrypted_key = vec![];
+
+        // Read our iv, salt, mac, and encrypted key from our key file.
+        key_file.read_exact(&mut version)?;
+        key_file.read_exact(&mut iv)?;
+        key_file.read_exact(&mut salt)?;
+        key_file.read_exact(&mut expected_mac)?;
+
+        // Our key will be AES encrypted in CTR mode meaning the ciphertext
+        // will have the same size as the plaintext. Read at most KEY_SIZE
+        // bytes here so we don't end up filling up memory unnecessarily if
+        // someone modifies the file.
+        key_file
+            .take(KEY_SIZE as u64)
+            .read_to_end(&mut encrypted_key)?;
+
+        if version[0] != VERSION {
+            return Err(IoError::new(ErrorKind::Other, "invalid index store version").into());
+        }
+
+        // Rederive our key using the passphrase and salt.
+        let (key, hmac_key) = EncryptedMmapDirectory::rederive_key(passphrase, &salt);
+
+        // First check our MAC of the encrypted key.
+        let expected_mac = MacResult::new(&expected_mac);
+        let mac = EncryptedMmapDirectory::calculate_hmac(
+            version[0],
+            &iv,
+            &salt,
+            &encrypted_key,
+            &hmac_key,
+        );
+
+        if mac != expected_mac {
+            return Err(IoError::new(ErrorKind::Other, "invalid MAC of the store key").into());
+        }
+
+        let algorithm = AesSafe256Encryptor::new(&key);
+        let mut decryptor = CtrMode::new(algorithm, iv.to_vec());
+
+        let mut out = Zeroizing::new(vec![0u8; KEY_SIZE]);
+        let mut write_buf = RefWriteBuffer::new(&mut out);
+
+        let remaining;
+        // Decrypt the encrypted key and return it.
+        let res;
+        {
+            let mut read_buf = RefReadBuffer::new(&encrypted_key);
+            res = decryptor
+                .decrypt(&mut read_buf, &mut write_buf, true)
+                .map_err(|e| {
+                    IoError::new(
+                        ErrorKind::Other,
+                        format!("error decrypting store key: {:?}", e),
+                    )
+                })?;
+            remaining = read_buf.remaining();
+        }
+
+        if remaining != 0 {
+            return Err(IoError::new(
+                ErrorKind::Other,
+                "unable to decrypt complete store key ciphertext",
+            )
+            .into());
+        }
+
+        match res {
+            BufferResult::BufferUnderflow => (),
+            BufferResult::BufferOverflow => {
+                return Err(IoError::new(ErrorKind::Other, "error decrypting store key").into())
+            }
+        }
+
+        Ok(out)
+    }
+
+    /// Calculate a HMAC for the given inputs.
+    fn calculate_hmac(
+        version: u8,
+        iv: &[u8],
+        salt: &[u8],
+        encrypted_data: &[u8],
+        hmac_key: &[u8],
+    ) -> MacResult {
+        let mut hmac = Hmac::new(Sha256::new(), hmac_key);
+        hmac.input(&[version]);
+        hmac.input(&iv);
+        hmac.input(&salt);
+        hmac.input(&encrypted_data);
+        hmac.result()
+    }
+
+    /// Create a new store key, encrypt it with the given passphrase and store
+    /// it in the given path.
+    fn create_new_store(
+        key_path: &Path,
+        passphrase: &str,
+    ) -> Result<KeyBuffer, OpenDirectoryError> {
+        // Derive a AES key from our passphrase using a randomly generated salt
+        // to prevent bruteforce attempts using rainbow tables.
+        let (key, hmac_key, salt) = EncryptedMmapDirectory::derive_key(passphrase)?;
+        // Generate a new random store key. This key will encrypt our tantivy
+        // indexing files. The key itself is stored encrypted using the derived
+        // key.
+        let store_key = EncryptedMmapDirectory::generate_key()?;
+
+        // Encrypt and save the encrypted store key to a file.
+        EncryptedMmapDirectory::encrypt_store_key(&key, &salt, &hmac_key, &store_key, key_path)?;
+
+        Ok(store_key)
+    }
+
+    /// Encrypt the given store key and save it in the given path.
+    fn encrypt_store_key(
+        key: &[u8],
+        salt: &[u8],
+        hmac_key: &[u8],
+        store_key: &[u8],
+        key_path: &Path,
+    ) -> Result<(), OpenDirectoryError> {
+        // Generate a random initialization vector for our AES encryptor.
+        let iv = EncryptedMmapDirectory::generate_iv()?;
+        let algorithm = AesSafe256Encryptor::new(&key);
+        let mut encryptor = CtrMode::new(algorithm, iv.clone());
+
+        let mut read_buf = RefReadBuffer::new(&store_key);
+        let mut out = [0u8; KEY_SIZE];
+        let mut write_buf = RefWriteBuffer::new(&mut out);
+        let mut encrypted_key = Vec::new();
+
+        let mut key_file = File::create(key_path)?;
+
+        // Write down our public salt and iv first, those will be needed to
+        // decrypt the key again.
+        key_file.write_all(&[VERSION])?;
+        key_file.write_all(&iv)?;
+        key_file.write_all(&salt)?;
+
+        // Encrypt our key.
+        let res = encryptor
+            .encrypt(&mut read_buf, &mut write_buf, true)
+            .map_err(|e| {
+                IoError::new(
+                    ErrorKind::Other,
+                    format!("unable to encrypt store key: {:?}", e),
+                )
+            })?;
+        let mut enc = write_buf.take_read_buffer();
+        let mut enc = Vec::from(enc.take_remaining());
+
+        encrypted_key.append(&mut enc);
+
+        match res {
+            BufferResult::BufferUnderflow => (),
+            _ => {
+                return Err(IoError::new(
+                    ErrorKind::Other,
+                    "unable to encrypt store key: unable to encrypt whole plaintext".to_string(),
+                )
+                .into());
+            }
+        }
+
+        // Calculate a MAC for our encrypted key and store it in the file before
+        // the key.
+        let mac =
+            EncryptedMmapDirectory::calculate_hmac(VERSION, &iv, &salt, &encrypted_key, &hmac_key);
+        key_file.write_all(mac.code())?;
+
+        // Write down the encrypted key.
+        key_file.write_all(&encrypted_key)?;
+
+        Ok(())
+    }
+
+    /// Generate a random IV.
+    fn generate_iv() -> Result<Vec<u8>, OpenDirectoryError> {
+        let mut iv = vec![0u8; IV_SIZE];
+        let mut rng = thread_rng();
+        rng.try_fill(&mut iv[..])
+            .map_err(|e| IoError::new(ErrorKind::Other, format!("error generating iv: {:?}", e)))?;
+        Ok(iv)
+    }
+
+    /// Generate a random key.
+    fn generate_key() -> Result<KeyBuffer, OpenDirectoryError> {
+        let mut key = Zeroizing::new(vec![0u8; KEY_SIZE]);
+        let mut rng = thread_rng();
+        rng.try_fill(&mut key[..]).map_err(|e| {
+            IoError::new(ErrorKind::Other, format!("error generating key: {:?}", e))
+        })?;
+        Ok(key)
+    }
+
+    /// Derive two keys from the given passphrase and the given salt using PBKDF2.
+    fn rederive_key(passphrase: &str, salt: &[u8]) -> KeyDerivationResult {
+        let mut mac = Hmac::new(Sha512::new(), passphrase.as_bytes());
+        let mut pbkdf_result = Zeroizing::new([0u8; KEY_SIZE * 2]);
+
+        pbkdf2(&mut mac, &salt, PBKDF_COUNT, &mut *pbkdf_result);
+        let (key, hmac_key) = pbkdf_result.split_at(KEY_SIZE);
+        (
+            Zeroizing::new(Vec::from(key)),
+            Zeroizing::new(Vec::from(hmac_key)),
+        )
+    }
+
+    /// Generate a random salt and derive two keys from the salt and the given
+    /// passphrase.
+    fn derive_key(passphrase: &str) -> Result<InitialKeyDerivationResult, OpenDirectoryError> {
+        let mut rng = thread_rng();
+        let mut salt = vec![0u8; SALT_SIZE];
+        rng.try_fill(&mut salt[..]).map_err(|e| {
+            IoError::new(ErrorKind::Other, format!("error generating salt: {:?}", e))
+        })?;
+
+        let (key, hmac_key) = EncryptedMmapDirectory::rederive_key(passphrase, &salt);
+        Ok((key, hmac_key, salt))
+    }
+}
+
+// The Directory trait[dr] implementation for our EncryptedMmapDirectory.
+// [dr] https://docs.rs/tantivy/0.10.2/tantivy/directory/trait.Directory.html
+impl Directory for EncryptedMmapDirectory {
+    fn open_read(&self, path: &Path) -> Result<ReadOnlySource, OpenReadError> {
+        let source = self.mmap_dir.open_read(path)?;
+
+        let decryptor = AesSafe256Encryptor::new(&self.encryption_key);
+        let mac = Hmac::new(Sha256::new(), &self.mac_key);
+        let mut reader = AesReader::new(Cursor::new(source.as_slice()), decryptor, mac)
+            .map_err(TvIoError::from)?;
+        let mut decrypted = Vec::new();
+
+        reader
+            .read_to_end(&mut decrypted)
+            .map_err(TvIoError::from)?;
+
+        Ok(ReadOnlySource::from(decrypted))
+    }
+
+    fn delete(&self, path: &Path) -> Result<(), DeleteError> {
+        self.mmap_dir.delete(path)
+    }
+
+    fn exists(&self, path: &Path) -> bool {
+        self.mmap_dir.exists(path)
+    }
+
+    fn open_write(&mut self, path: &Path) -> Result<WritePtr, OpenWriteError> {
+        let file = match self.mmap_dir.open_write(path)?.into_inner() {
+            Ok(f) => f,
+            Err(e) => {
+                let error = IoError::from(e);
+                return Err(TvIoError::from(error).into());
+            }
+        };
+
+        let encryptor = AesSafe256Encryptor::new(&self.encryption_key);
+        let mac = Hmac::new(Sha256::new(), &self.mac_key);
+        let writer = AesWriter::new(file, encryptor, mac).map_err(TvIoError::from)?;
+        Ok(BufWriter::new(Box::new(writer)))
+    }
+
+    fn atomic_read(&self, path: &Path) -> Result<Vec<u8>, OpenReadError> {
+        let data = self.mmap_dir.atomic_read(path)?;
+
+        let decryptor = AesSafe256Encryptor::new(&self.encryption_key);
+        let mac = Hmac::new(Sha256::new(), &self.mac_key);
+        let mut reader =
+            AesReader::new(Cursor::new(data), decryptor, mac).map_err(TvIoError::from)?;
+        let mut decrypted = Vec::new();
+
+        reader
+            .read_to_end(&mut decrypted)
+            .map_err(TvIoError::from)?;
+        Ok(decrypted)
+    }
+
+    fn atomic_write(&mut self, path: &Path, data: &[u8]) -> std::io::Result<()> {
+        let encryptor = AesSafe256Encryptor::new(&self.encryption_key);
+        let mac = Hmac::new(Sha256::new(), &self.mac_key);
+        let mut encrypted = Vec::new();
+        {
+            let mut writer = AesWriter::new(&mut encrypted, encryptor, mac)?;
+            writer.write_all(data)?;
+        }
+
+        self.mmap_dir.atomic_write(path, &encrypted)
+    }
+
+    fn watch(&self, watch_callback: WatchCallback) -> Result<WatchHandle, tantivy::Error> {
+        self.mmap_dir.watch(watch_callback)
+    }
+
+    fn acquire_lock(&self, lock: &Lock) -> Result<DirectoryLock, LockError> {
+        // The lock files aren't encrypted, this is fine since they won't
+        // contain any data. They will be an empty file and a lock will be
+        // placed on them using e.g. flock(2) on macOS and Linux.
+        self.mmap_dir.acquire_lock(lock)
+    }
+}
+
+// This tantivy trait is used to indicate when no more writes are expected to be
+// done on a writer.
+impl<E: crypto::symmetriccipher::BlockEncryptor, M: Mac, W: Write> TerminatingWrite
+    for AesWriter<E, M, W>
+{
+    fn terminate_ref(&mut self, _: AntiCallToken) -> std::io::Result<()> {
+        self.finalize()
+    }
+}
+
+#[cfg(test)]
+use tempfile::tempdir;
+
+#[test]
+fn create_new_store_and_reopen() {
+    let tmpdir = tempdir().unwrap();
+    let dir =
+        EncryptedMmapDirectory::open(tmpdir.path(), "wordpass").expect("Can't create a new store");
+    drop(dir);
+    let dir = EncryptedMmapDirectory::open(tmpdir.path(), "wordpass")
+        .expect("Can't open the existing store");
+    drop(dir);
+    let dir = EncryptedMmapDirectory::open(tmpdir.path(), "password");
+    assert!(
+        dir.is_err(),
+        "Opened an existing store with the wrong passphrase"
+    );
+}
+
+#[test]
+fn create_store_with_empty_passphrase() {
+    let tmpdir = tempdir().unwrap();
+    let dir = EncryptedMmapDirectory::open(tmpdir.path(), "");
+    assert!(
+        dir.is_err(),
+        "Opened an existing store with the wrong passphrase"
+    );
+}
+
+#[test]
+fn change_passphrase() {
+    let tmpdir = tempdir().unwrap();
+    let dir =
+        EncryptedMmapDirectory::open(tmpdir.path(), "wordpass").expect("Can't create a new store");
+
+    drop(dir);
+    EncryptedMmapDirectory::change_passphrase(tmpdir.path(), "wordpass", "password")
+        .expect("Can't change passphrase");
+    let dir = EncryptedMmapDirectory::open(tmpdir.path(), "wordpass");
+    assert!(
+        dir.is_err(),
+        "Opened an existing store with the old passphrase"
+    );
+    let _ = EncryptedMmapDirectory::open(tmpdir.path(), "password")
+        .expect("Can't open the store with the new passphrase");
+}

--- a/src/encrypted_stream.rs
+++ b/src/encrypted_stream.rs
@@ -1,0 +1,515 @@
+// Copyright 2015 The adb-remote-control Developers
+// Copyright 2019 The Matrix.org Foundation C.I.C.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+// This file originates from the rust-aes-stream repo[1], it has been moddified
+// to use AES-CTR mode and to authenticate the encrypted files.
+// [1] https://github.com/oberien/rust-aes-stream/
+
+//! Read/Write Wrapper for AES Encryption and Decryption during I/O Operations
+//!
+use std::cmp;
+use std::convert::TryFrom;
+use std::io::{Error, ErrorKind, Read, Result, Seek, SeekFrom, Write};
+use std::ops::Neg;
+
+use crypto::blockmodes::CtrMode;
+use crypto::buffer::{BufferResult, ReadBuffer, RefReadBuffer, RefWriteBuffer, WriteBuffer};
+use crypto::mac::{Mac, MacResult};
+use crypto::symmetriccipher::{BlockEncryptor, Decryptor, Encryptor};
+use rand::{thread_rng, Rng};
+
+const BUFFER_SIZE: usize = 8192;
+
+// TODO We may want to generalize our writer/reader to take an Encryptor instead
+// of a BlockEncryptor. This would allow us to swap easily between different
+// encryption algorithms like we can swap between different MAC algorithms. This
+// would require the new() method to take the IV/Nonce as an argument.
+// Chacha20/Poly1305 would be available to us this way.
+
+/// Wraps a [`Write`](https://doc.rust-lang.org/std/io/trait.Write.html) implementation with CTR
+/// based on the given [`BlockEncryptor`][be], additionally authenticates the
+/// writer with the given [`Mac`][mac]
+///
+/// [be]: https://docs.rs/rust-crypto/0.2.36/crypto/symmetriccipher/trait.BlockEncryptor.html
+/// [mac]: https://docs.rs/rust-crypto/0.2.36/crypto/mac/trait.Mac.html
+///
+pub struct AesWriter<E: BlockEncryptor, M: Mac, W: Write> {
+    /// Writer to write encrypted data to
+    writer: W,
+    /// Encryptor to encrypt data with
+    enc: CtrMode<E>,
+    mac: M,
+    finalized: bool,
+}
+
+impl<E: BlockEncryptor, M: Mac, W: Write> AesWriter<E, M, W> {
+    /// Creates a new AesWriter with a random IV.
+    ///
+    /// The IV will be written as first block of the file.
+    ///
+    /// The MAC will be written at the end of the file.
+    ///
+    /// # Arguments
+    ///
+    /// * `writer`: Writer to write encrypted data into
+    /// * `enc`: [`BlockEncryptor`][be] to use for encyrption
+    /// * `mac`: [`Mac`][mac] to use for encyrption
+    ///
+    /// [be]: https://docs.rs/rust-crypto/0.2.36/crypto/symmetriccipher/trait.BlockEncryptor.html
+    /// [mac]: https://docs.rs/rust-crypto/0.2.36/crypto/mac/trait.Mac.html
+    pub fn new(mut writer: W, enc: E, mac: M) -> Result<AesWriter<E, M, W>> {
+        let mut iv = vec![0u8; enc.block_size()];
+        let mut rng = thread_rng();
+
+        rng.try_fill(&mut iv[..])
+            .map_err(|e| Error::new(ErrorKind::Other, format!("error generating iv: {:?}", e)))?;
+        writer.write_all(&iv)?;
+        Ok(AesWriter {
+            writer,
+            enc: CtrMode::new(enc, iv),
+            mac,
+            finalized: false,
+        })
+    }
+
+    /// Encrypts the passed buffer and writes all resulting encrypted blocks to the underlying writer
+    ///
+    /// # Arguments
+    ///
+    /// * `buf`: Plaintext to encrypt and write.
+    fn encrypt_write(&mut self, buf: &[u8], eof: bool) -> Result<usize> {
+        if self.finalized {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "File has been already finalized",
+            ));
+        }
+
+        let mut read_buf = RefReadBuffer::new(buf);
+        let mut out = [0u8; BUFFER_SIZE];
+        let mut write_buf = RefWriteBuffer::new(&mut out);
+        loop {
+            let res = self
+                .enc
+                .encrypt(&mut read_buf, &mut write_buf, eof)
+                .map_err(|e| Error::new(ErrorKind::Other, format!("encryption error: {:?}", e)))?;
+            let mut enc = write_buf.take_read_buffer();
+            let enc = enc.take_remaining();
+            self.writer.write_all(enc)?;
+            self.mac.input(enc);
+            match res {
+                BufferResult::BufferUnderflow => break,
+                BufferResult::BufferOverflow => {}
+            }
+        }
+        assert_eq!(read_buf.remaining(), 0);
+        Ok(buf.len())
+    }
+
+    /// Finalize the file and mark it so no more writes can happen.
+    pub fn finalize(&mut self) -> Result<()> {
+        // If our encryptor is using padding this write will insert it now.
+        // Otherwise it will do nothing.
+        self.encrypt_write(&[], true)?;
+
+        // Write our mac after our encrypted data.
+        let mac_result = self.mac.result();
+        self.writer.write_all(mac_result.code())?;
+
+        // Mark the file as finalized and flush our underlying writer.
+        self.finalized = true;
+        self.flush()?;
+
+        Ok(())
+    }
+}
+
+impl<E: BlockEncryptor, M: Mac, W: Write> Write for AesWriter<E, M, W> {
+    /// Encrypts the passed buffer and writes the result to the underlying writer.
+    fn write(&mut self, buf: &[u8]) -> Result<usize> {
+        let written = self.encrypt_write(buf, false)?;
+        Ok(written)
+    }
+
+    /// Flush this output stream, ensuring that all intermediately buffered contents reach their destination.
+    /// [Read more](https://doc.rust-lang.org/nightly/std/io/trait.Write.html#tymethod.flush)
+    fn flush(&mut self) -> Result<()> {
+        self.writer.flush()
+    }
+}
+
+impl<E: BlockEncryptor, M: Mac, W: Write> Drop for AesWriter<E, M, W> {
+    /// Drop our AesWriter adding the MAC at the end of the file and flushing
+    /// our buffers.
+    fn drop(&mut self) {
+        if self.finalized {
+            return;
+        }
+
+        if std::thread::panicking() {
+            let _ = self.finalize();
+        } else {
+            self.finalize().unwrap();
+        }
+    }
+}
+
+/// Wraps a [`Read`](https://doc.rust-lang.org/std/io/trait.Read.html) implementation with CTR
+/// based on given [`CtrMode`][ct]
+///
+/// [ct]: https://docs.rs/rust-crypto/0.2.36/crypto/blockmodes/struct.CtrMode.html
+pub struct AesReader<D: BlockEncryptor, R: Read + Seek> {
+    /// Reader to read encrypted data from
+    reader: R,
+    /// Decryptor to decrypt data with
+    dec: CtrMode<D>,
+    /// Buffer used to store blob needed to find out if we reached eof
+    buffer: Vec<u8>,
+    /// Indicates wheather eof of the underlying buffer was reached
+    eof: bool,
+    /// Total length of the reader
+    length: u64,
+    /// Length of the MAC.
+    mac_length: u64,
+}
+
+impl<D: BlockEncryptor, R: Read + Seek> AesReader<D, R> {
+    /// Creates a new AesReader.
+    ///
+    /// Assumes that the first block of given reader is the IV.
+    ///
+    /// # Arguments
+    ///
+    /// * `reader`: Reader to read encrypted data from
+    /// * `dec`: [`BlockDecryptor`][bd] to use for decyrption
+    /// * `mac`: [`Mac`][mac] to use for authentication
+    ///
+    /// [bd]: https://docs.rs/rust-crypto/0.2.36/crypto/symmetriccipher/trait.BlockDecryptor.html
+    /// [mac]: https://docs.rs/rust-crypto/0.2.36/crypto/mac/trait.Mac.html
+    pub fn new<M: Mac>(mut reader: R, dec: D, mut mac: M) -> Result<AesReader<D, R>> {
+        let iv_length = dec.block_size();
+        let mac_length = mac.output_bytes();
+
+        let u_iv_length = u64::try_from(iv_length)
+            .map_err(|_| Error::new(ErrorKind::Other, "IV length is too big"))?;
+        let u_mac_length = u64::try_from(mac_length)
+            .map_err(|_| Error::new(ErrorKind::Other, "MAC length is too big"))?;
+        let i_mac_length = i64::try_from(mac_length)
+            .map_err(|_| Error::new(ErrorKind::Other, "MAC length is too big"))?;
+
+        let mut iv = vec![0u8; iv_length];
+        let mut expected_mac = vec![0u8; mac_length];
+
+        reader.read_exact(&mut iv)?;
+        let end = reader.seek(SeekFrom::End(0))?;
+
+        if end < (u_iv_length + u_mac_length) {
+            return Err(Error::new(
+                ErrorKind::Other,
+                "File doesn't contain a valid IV or MAC",
+            ));
+        }
+
+        let seek_back = i_mac_length.neg();
+        reader.seek(SeekFrom::End(seek_back))?;
+        reader.read_exact(&mut expected_mac)?;
+        let expected_mac = MacResult::new_from_owned(expected_mac);
+
+        reader.seek(SeekFrom::Start(u_iv_length))?;
+
+        let mut eof = false;
+
+        while !eof {
+            let (buffer, end_of_file) =
+                AesReader::<D, R>::read_until_mac(&mut reader, end, u_mac_length)?;
+            eof = end_of_file;
+            mac.input(&buffer);
+        }
+
+        if mac.result() != expected_mac {
+            return Err(Error::new(ErrorKind::Other, "Invalid MAC"));
+        }
+
+        reader.seek(SeekFrom::Start(u_iv_length))?;
+
+        Ok(AesReader {
+            reader,
+            dec: CtrMode::new(dec, iv),
+            buffer: Vec::new(),
+            eof: false,
+            length: end,
+            mac_length: u_mac_length,
+        })
+    }
+
+    /// Read bytes from a reader until the start of the MAC instead of until the
+    /// end of file.
+    ///
+    /// # Arguments
+    ///
+    /// * `reader`: Reader to read encrypted data from
+    /// * `total_length`: The total number of bytes that the reader contains.
+    /// * `mac_length`: The length of the MAC that is stored the file we are
+    /// reading from.
+    fn read_until_mac(
+        reader: &mut R,
+        total_length: u64,
+        mac_length: u64,
+    ) -> Result<(Vec<u8>, bool)> {
+        let mut buffer = vec![0u8; BUFFER_SIZE];
+        let read = reader.read(&mut buffer)?;
+
+        let current_pos = reader.seek(SeekFrom::Current(0))?;
+        let mac_start = total_length - mac_length;
+        let read_mac_bytes = cmp::max(current_pos - mac_start, 0);
+        let eof = current_pos >= mac_start;
+
+        let read_mac_bytes = usize::try_from(read_mac_bytes).map_err(|_| {
+            Error::new(
+                ErrorKind::Other,
+                "Cannot convert the number of read MAC bytes.",
+            )
+        })?;
+
+        buffer.truncate(read - read_mac_bytes);
+
+        Ok((buffer, eof))
+    }
+
+    /// Reads at max BUFFER_SIZE bytes, handles potential eof and returns the
+    /// buffer as Vec<u8>
+    fn fill_buf(&mut self) -> Result<Vec<u8>> {
+        let (buffer, eof) =
+            AesReader::<D, R>::read_until_mac(&mut self.reader, self.length, self.mac_length)?;
+        self.eof = eof;
+        Ok(buffer)
+    }
+
+    /// Reads and decrypts data from the underlying stream and writes it into the passed buffer.
+    ///
+    /// # Arguments
+    ///
+    /// * `buf`: Buffer to write decrypted data into.
+    fn read_decrypt(&mut self, buf: &mut [u8]) -> Result<usize> {
+        // If this is the first iteration, fill our internal buffer
+        if self.buffer.is_empty() && !self.eof {
+            self.buffer = self.fill_buf()?;
+        }
+
+        let buf_len = buf.len();
+        let mut write_buf = RefWriteBuffer::new(buf);
+        let res;
+        let remaining;
+        {
+            let mut read_buf = RefReadBuffer::new(&self.buffer);
+
+            // Test if our decryptor still has enough decrypted data or we have
+            // enough buffered.
+            res = self
+                .dec
+                .decrypt(&mut read_buf, &mut write_buf, self.eof)
+                .map_err(|e| Error::new(ErrorKind::Other, format!("decryption error: {:?}", e)))?;
+            remaining = read_buf.remaining();
+        }
+        // Keep the remaining bytes
+        let len = self.buffer.len();
+        self.buffer.drain(..(len - remaining));
+
+        // If we were able to decrypt the whole file, return early.
+        match res {
+            BufferResult::BufferOverflow => return Ok(buf_len),
+            BufferResult::BufferUnderflow if self.eof => return Ok(write_buf.position()),
+            _ => {}
+        }
+
+        // Otherwise read/decrypt more.
+        let mut dec_len = 0;
+        // If the reader doesn't return enough so that we can decrypt a block,
+        // we need to continue reading until we have enough data to return one
+        // decrypted block, or until we reach eof.
+        while dec_len == 0 && !self.eof {
+            let eof_buffer = self.fill_buf()?;
+            let remaining;
+            {
+                let mut read_buf = RefReadBuffer::new(&self.buffer);
+                self.dec
+                    .decrypt(&mut read_buf, &mut write_buf, self.eof)
+                    .map_err(|e| {
+                        Error::new(ErrorKind::Other, format!("decryption error: {:?}", e))
+                    })?;
+                let mut dec = write_buf.take_read_buffer();
+                let dec = dec.take_remaining();
+                dec_len = dec.len();
+                remaining = read_buf.remaining();
+            }
+            // Keep the remaining bytes
+            let len = self.buffer.len();
+            self.buffer.drain(..(len - remaining));
+            // Append the newly read bytes
+            self.buffer.extend(eof_buffer);
+        }
+        Ok(dec_len)
+    }
+}
+
+impl<D: BlockEncryptor, R: Read + Seek> Read for AesReader<D, R> {
+    /// Reads encrypted data from the underlying reader, decrypts it and writes the result into the
+    /// passed buffer.
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize> {
+        let read = self.read_decrypt(buf)?;
+        Ok(read)
+    }
+}
+
+#[cfg(test)]
+use crypto::aessafe::AesSafe128Encryptor;
+
+#[cfg(test)]
+use crypto::hmac::Hmac;
+
+#[cfg(test)]
+use crypto::poly1305::Poly1305;
+
+#[cfg(test)]
+use crypto::sha2::Sha256;
+
+#[cfg(test)]
+use std::io::Cursor;
+
+#[cfg(test)]
+fn encrypt(data: &[u8]) -> Vec<u8> {
+    let key = [0u8; 16];
+    let hmac_key = [0u8; 16];
+
+    let mac = Hmac::new(Sha256::new(), &hmac_key);
+    let block_enc = AesSafe128Encryptor::new(&key);
+    let mut enc = Vec::new();
+    {
+        let mut aes = AesWriter::new(&mut enc, block_enc, mac).unwrap();
+        aes.write_all(&data).unwrap();
+    }
+    enc
+}
+
+#[cfg(test)]
+fn encrypt_poly1305(data: &[u8]) -> Vec<u8> {
+    let key = [0u8; 16];
+    let hmac_key = [0u8; 32];
+
+    let mac = Poly1305::new(&hmac_key);
+    let block_enc = AesSafe128Encryptor::new(&key);
+    let mut enc = Vec::new();
+    {
+        let mut aes = AesWriter::new(&mut enc, block_enc, mac).unwrap();
+        aes.write_all(&data).unwrap();
+    }
+    enc
+}
+
+#[cfg(test)]
+fn decrypt<R: Read + Seek>(data: R) -> Vec<u8> {
+    let key = [0u8; 16];
+    let block_dec = AesSafe128Encryptor::new(&key);
+    let mut dec = Vec::new();
+    let hmac = Hmac::new(Sha256::new(), &key);
+    let mut aes = AesReader::new(data, block_dec, hmac).unwrap();
+    aes.read_to_end(&mut dec).unwrap();
+    dec
+}
+
+#[cfg(test)]
+fn decrypt_poly1305<R: Read + Seek>(data: R) -> Vec<u8> {
+    let key = [0u8; 16];
+    let hmac_key = [0u8; 32];
+    let block_dec = AesSafe128Encryptor::new(&key);
+    let mut dec = Vec::new();
+    let hmac = Poly1305::new(&hmac_key);
+    let mut aes = AesReader::new(data, block_dec, hmac).unwrap();
+    aes.read_to_end(&mut dec).unwrap();
+    dec
+}
+
+#[test]
+fn enc_unaligned() {
+    let orig = [0u8; 16];
+    let key = [0u8; 16];
+    let hmac_key = [0u8; 16];
+
+    let mac = Hmac::new(Sha256::new(), &hmac_key);
+    let block_enc = AesSafe128Encryptor::new(&key);
+    let mut enc = Vec::new();
+    {
+        let mut aes = AesWriter::new(&mut enc, block_enc, mac).unwrap();
+        for chunk in orig.chunks(3) {
+            aes.write_all(&chunk).unwrap();
+        }
+    }
+    let dec = decrypt(Cursor::new(&enc));
+    assert_eq!(dec, &orig);
+}
+
+#[test]
+fn enc_dec_single() {
+    let orig = [0u8; 15];
+    let enc = encrypt(&orig);
+    let dec = decrypt(Cursor::new(&enc));
+    assert_eq!(dec, &orig);
+}
+
+#[test]
+fn enc_dec_single_poly() {
+    let orig = [0u8; 15];
+    let enc = encrypt_poly1305(&orig);
+    let dec = decrypt_poly1305(Cursor::new(&enc));
+    assert_eq!(dec, &orig);
+}
+
+#[test]
+fn enc_dec_single_full() {
+    let orig = [0u8; 16];
+    let enc = encrypt(&orig);
+    let dec = decrypt(Cursor::new(&enc));
+    assert_eq!(dec, &orig);
+}
+
+#[test]
+fn enc_dec_single_full_poly() {
+    let orig = [0u8; 16];
+    let enc = encrypt_poly1305(&orig);
+    let dec = decrypt_poly1305(Cursor::new(&enc));
+    assert_eq!(dec, &orig);
+}
+
+#[test]
+fn dec_read_unaligned() {
+    let orig = [0u8; 16];
+    let enc = encrypt(&orig);
+
+    let key = [0u8; 16];
+    let block_dec = AesSafe128Encryptor::new(&key);
+    let mut dec: Vec<u8> = Vec::new();
+    let hmac = Hmac::new(Sha256::new(), &key);
+    let mut aes = AesReader::new(Cursor::new(&enc), block_dec, hmac).unwrap();
+    loop {
+        let mut buf = [0u8; 3];
+        let read = aes.read(&mut buf).unwrap();
+        dec.extend(&buf[..read]);
+        if read == 0 {
+            break;
+        }
+    }
+    assert_eq!(dec, &orig);
+}

--- a/src/encrypted_stream.rs
+++ b/src/encrypted_stream.rs
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-
 // This file originates from the rust-aes-stream repo[1], it has been moddified
 // to use AES-CTR mode and to authenticate the encrypted files.
 // [1] https://github.com/oberien/rust-aes-stream/

--- a/src/encrypted_stream.rs
+++ b/src/encrypted_stream.rs
@@ -65,8 +65,8 @@ impl<E: BlockEncryptor, M: Mac, W: Write> AesWriter<E, M, W> {
     /// # Arguments
     ///
     /// * `writer`: Writer to write encrypted data into
-    /// * `enc`: [`BlockEncryptor`][be] to use for encyrption
-    /// * `mac`: [`Mac`][mac] to use for encyrption
+    /// * `enc`: [`BlockEncryptor`][be] to use for encryption
+    /// * `mac`: [`Mac`][mac] to use for encryption
     ///
     /// [be]: https://docs.rs/rust-crypto/0.2.36/crypto/symmetriccipher/trait.BlockEncryptor.html
     /// [mac]: https://docs.rs/rust-crypto/0.2.36/crypto/mac/trait.Mac.html

--- a/src/error.rs
+++ b/src/error.rs
@@ -39,6 +39,18 @@ pub enum Error {
     /// Error signaling that there was an error while reading from the
     /// filesystem.
     FsError(fs_extra::error::Error),
+    /// Error signaling that the database passphrase was incorrect.
+    #[fail(display = "Error unlocking the database: {}", _0)]
+    DatabaseUnlockError(String),
+    /// Error when opening the Seshat database and reading the database version.
+    #[fail(display = "Database version missmatch.")]
+    DatabaseVersionError,
+    /// Error when opening the Seshat database and reading the database version.
+    #[fail(display = "Error opening the database: {}", _0)]
+    DatabaseOpenError(String),
+    /// Error signaling that sqlcipher support is missing.
+    #[fail(display = "Sqlcipher error: {}", _0)]
+    SqlCipherError(String),
 }
 
 impl From<r2d2::Error> for Error {

--- a/src/index.rs
+++ b/src/index.rs
@@ -17,7 +17,7 @@ use tantivy as tv;
 use tantivy::tokenizer::Tokenizer;
 
 use crate::config::{Config, Language, SearchConfig};
-use crate::encrypted_dir::EncryptedMmapDirectory;
+use crate::encrypted_dir::{EncryptedMmapDirectory, PBKDF_COUNT};
 use crate::events::{Event, EventId, EventType};
 use crate::japanese_tokenizer::TinySegmenterTokenizer;
 
@@ -170,7 +170,7 @@ impl Index {
 
         let index = match &config.passphrase {
             Some(p) => {
-                let dir = EncryptedMmapDirectory::open(path, &p)?;
+                let dir = EncryptedMmapDirectory::open_or_create(path, &p, PBKDF_COUNT)?;
                 tv::Index::open_or_create(dir, schema)?
             }
             None => {
@@ -213,7 +213,12 @@ impl Index {
         old_passphrase: &str,
         new_passphrase: &str,
     ) -> Result<(), tv::Error> {
-        EncryptedMmapDirectory::change_passphrase(path, old_passphrase, new_passphrase)?;
+        EncryptedMmapDirectory::change_passphrase(
+            path,
+            old_passphrase,
+            new_passphrase,
+            PBKDF_COUNT,
+        )?;
         Ok(())
     }
 

--- a/src/index.rs
+++ b/src/index.rs
@@ -16,12 +16,13 @@ use std::path::Path;
 use tantivy as tv;
 use tantivy::tokenizer::Tokenizer;
 
-use crate::config::{Language, SearchConfig};
+use crate::config::{Config, Language, SearchConfig};
+use crate::encrypted_dir::EncryptedMmapDirectory;
 use crate::events::{Event, EventId, EventType};
 use crate::japanese_tokenizer::TinySegmenterTokenizer;
 
 // Tantivy requires at least 3MB per writer thread and will panic if we
-// give it less than 3MB for the total writer heap size. The amount of writer 
+// give it less than 3MB for the total writer heap size. The amount of writer
 // threads that Tantivy will spawn depends on the amount of heap we give it.
 // The logic for the number of threads is as follows:
 //
@@ -152,8 +153,8 @@ impl IndexSearcher {
 }
 
 impl Index {
-    pub fn new<P: AsRef<Path>>(path: P, language: &Language) -> Result<Index, tv::Error> {
-        let tokenizer_name = language.as_tokenizer_name();
+    pub fn new<P: AsRef<Path>>(path: P, config: &Config) -> Result<Index, tv::Error> {
+        let tokenizer_name = config.language.as_tokenizer_name();
 
         let text_field_options = Index::create_text_options(&tokenizer_name);
         let mut schemabuilder = tv::schema::Schema::builder();
@@ -167,12 +168,20 @@ impl Index {
 
         let schema = schemabuilder.build();
 
-        let index_dir = tv::directory::MmapDirectory::open(path)?;
+        let index = match &config.passphrase {
+            Some(p) => {
+                let dir = EncryptedMmapDirectory::open(path, &p)?;
+                tv::Index::open_or_create(dir, schema)?
+            }
+            None => {
+                let dir = tv::directory::MmapDirectory::open(path)?;
+                tv::Index::open_or_create(dir, schema)?
+            }
+        };
 
-        let index = tv::Index::open_or_create(index_dir, schema)?;
         let reader = index.reader()?;
 
-        match language {
+        match config.language {
             Language::Unknown => (),
             Language::Japanese => {
                 index
@@ -183,7 +192,7 @@ impl Index {
                 let tokenizer = tv::tokenizer::SimpleTokenizer
                     .filter(tv::tokenizer::RemoveLongFilter::limit(40))
                     .filter(tv::tokenizer::LowerCaser)
-                    .filter(tv::tokenizer::Stemmer::new(language.as_tantivy()));
+                    .filter(tv::tokenizer::Stemmer::new(config.language.as_tantivy()));
                 index.tokenizers().register(&tokenizer_name, tokenizer);
             }
         }
@@ -197,6 +206,15 @@ impl Index {
             event_id_field,
             room_id_field,
         })
+    }
+
+    pub fn change_passphrase<P: AsRef<Path>>(
+        path: P,
+        old_passphrase: &str,
+        new_passphrase: &str,
+    ) -> Result<(), tv::Error> {
+        EncryptedMmapDirectory::change_passphrase(path, old_passphrase, new_passphrase)?;
+        Ok(())
     }
 
     fn create_text_options(tokenizer: &str) -> tv::schema::TextOptions {
@@ -242,7 +260,8 @@ impl Index {
 #[test]
 fn add_an_event() {
     let tmpdir = TempDir::new().unwrap();
-    let index = Index::new(&tmpdir, &Language::English).unwrap();
+    let config = Config::new().set_language(&Language::English);
+    let index = Index::new(&tmpdir, &config).unwrap();
 
     let mut writer = index.get_writer().unwrap();
 
@@ -262,7 +281,8 @@ fn add_an_event() {
 #[test]
 fn add_events_to_differing_rooms() {
     let tmpdir = TempDir::new().unwrap();
-    let index = Index::new(&tmpdir, &Language::English).unwrap();
+    let config = Config::new().set_language(&Language::English);
+    let index = Index::new(&tmpdir, &config).unwrap();
 
     let event_id = EVENT.event_id.to_string();
     let mut writer = index.get_writer().unwrap();
@@ -291,7 +311,8 @@ fn add_events_to_differing_rooms() {
 #[test]
 fn switch_languages() {
     let tmpdir = TempDir::new().unwrap();
-    let index = Index::new(&tmpdir, &Language::English).unwrap();
+    let config = Config::new().set_language(&Language::English);
+    let index = Index::new(&tmpdir, &config).unwrap();
 
     let mut writer = index.get_writer().unwrap();
 
@@ -309,7 +330,8 @@ fn switch_languages() {
 
     drop(index);
 
-    let index = Index::new(&tmpdir, &Language::German);
+    let config = Config::new().set_language(&Language::German);
+    let index = Index::new(&tmpdir, &config);
 
     assert!(index.is_err())
 }
@@ -317,7 +339,8 @@ fn switch_languages() {
 #[test]
 fn japanese_tokenizer() {
     let tmpdir = TempDir::new().unwrap();
-    let index = Index::new(&tmpdir, &Language::Japanese).unwrap();
+    let config = Config::new().set_language(&Language::Japanese);
+    let index = Index::new(&tmpdir, &config).unwrap();
 
     let mut writer = index.get_writer().unwrap();
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,8 @@ extern crate lazy_static;
 
 mod config;
 mod database;
+mod encrypted_dir;
+mod encrypted_stream;
 mod error;
 mod events;
 mod index;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,7 +2,8 @@
 extern crate lazy_static;
 
 use seshat::{
-    Config, CheckpointDirection, CrawlerCheckpoint, Database, Event, EventType, Profile, SearchConfig,
+    CheckpointDirection, Config, CrawlerCheckpoint, Database, Event, EventType, Profile,
+    SearchConfig,
 };
 
 use std::path::Path;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,7 +2,7 @@
 extern crate lazy_static;
 
 use seshat::{
-    CheckpointDirection, CrawlerCheckpoint, Database, Event, EventType, Profile, SearchConfig,
+    Config, CheckpointDirection, CrawlerCheckpoint, Database, Event, EventType, Profile, SearchConfig,
 };
 
 use std::path::Path;
@@ -230,4 +230,20 @@ fn delete() {
     db.delete().unwrap();
 
     assert!(!path.exists());
+}
+
+#[test]
+fn encrypted_save_and_search() {
+    let tmpdir = tempdir().unwrap();
+    let db_config = Config::new().set_passphrase("wordpass");
+    let mut db = Database::new_with_config(tmpdir.path(), &db_config).unwrap();
+    let profile = Profile::new("Alice", "");
+
+    db.add_event(EVENT.clone(), profile);
+    db.commit().unwrap();
+    db.reload().unwrap();
+
+    let result = db.search("Test", &Default::default()).unwrap();
+    assert!(!result.is_empty());
+    assert_eq!(result[0].event_source, EVENT.source);
 }


### PR DESCRIPTION
This PR implements encrypted storage for Seshat and tries to adress #1. 

We use SQLCipher to encrypt our database, SQLCipher is a SQLite extension which adds transparent AES encryption of the SQLite database.

The Seshat index is as well encrypted using a homegrown encrypted Directory implementation.

The Travis configuration is changed to use Ubuntu Bionic for the Linux build environment since there seems to be an issue with one of our system dependencies (probably SQLCipher) on the default Xenial build environment.

The PR depends on #14, which should be merged before this one.