### PR TITLE
Add the ablility to easily retrieve events containing MXC URLs

### DIFF
--- a/seshat-node/lib/index.js
+++ b/seshat-node/lib/index.js
@@ -323,6 +323,29 @@ class Seshat extends seshat.Seshat {
             });
         });
     }
+
+    /**
+     * Get events that contain an mxc URL to a file.
+     *
+     * @param  {object} args Arguments object for the method.
+     * @param  {string} args.roomId The ID of the room for which the events
+     * should be loaded.
+     * @param  {number} args.limit The maximum number of events to return.
+     * @param  {string} args.fromEvent An event id of a previous event returned
+     * by this method. If set events that are older than the event with the
+     * given event ID will be returned.
+     *
+     * @return {Promise<[matrixEvent]>} A promise that will resolve to an array
+     * of Matrix events that contain mxc URLs.
+     */
+    async getFileEvents(args) {
+        return new Promise((resolve, reject) => {
+            super.getFileEvents(args, (err, res) => {
+                if (err) reject(err);
+                else resolve(res);
+            });
+        });
+    }
 }
 
 module.exports = Seshat;

--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -21,4 +21,4 @@ serde_json = "1.0"
 r2d2 = "0.8"
 r2d2_sqlite = "0.12"
 neon-serde = "=0.2.0"
-seshat = { git = "https://github.com/matrix-org/seshat/", rev = "58da572" }
+seshat = { path = "../../" }

--- a/seshat-node/native/src/lib.rs
+++ b/seshat-node/native/src/lib.rs
@@ -869,6 +869,19 @@ fn parse_event(
             .value(),
     };
 
+    let msgtype = match event_type {
+        EventType::Message => Some(
+            content
+                .get(&mut *cx, "msgtype")?
+                .downcast::<JsString>()
+                .or_else(|_| {
+                    cx.throw_type_error("m.room.message event doesn't contain a valid msgtype")
+                })?
+                .value(),
+        ),
+        _ => None,
+    };
+
     let event_value = event.as_value(&mut *cx);
     let event_source: serde_json::Value = neon_serde::from_value(&mut *cx, event_value)?;
     let event_source: String = serde_json::to_string(&event_source)
@@ -882,6 +895,7 @@ fn parse_event(
         server_ts: server_timestamp,
         room_id,
         source: event_source,
+        msgtype: msgtype,
     })
 }
 

--- a/seshat-node/test/test.js
+++ b/seshat-node/test/test.js
@@ -13,6 +13,7 @@ const matrixEvent = {
     sender: '@alice:example.org',
     content: {
         body: 'Test message',
+        msgtype: 'm.text',
     },
     origin_server_ts: 1516362244026,
 };
@@ -24,6 +25,7 @@ const beforeMatrixEvent = {
     sender: '@alice:example.org',
     content: {
         body: 'Another test message before on',
+        msgtype: 'm.text',
     },
     origin_server_ts: 1516352244100,
 };
@@ -35,6 +37,7 @@ const laterMatrixEvent = {
     sender: '@alice:example.org',
     content: {
         body: 'Another test message later on',
+        msgtype: 'm.text',
     },
     origin_server_ts: 1516372244100,
 };
@@ -68,6 +71,7 @@ const matrixEventRoom2 = {
     sender: '@alice:example.org',
     content: {
         body: 'Test message',
+        msgtype: 'm.text',
     },
     origin_server_ts: 1516362244064,
 };
@@ -87,6 +91,7 @@ const badEvent = {
     sender: '@alice:example.org',
     content: {
         body: 'Test message',
+        msgtype: 'm.text',
     },
     origin_server_ts: '1516362244026',
 };

--- a/src/database.rs
+++ b/src/database.rs
@@ -119,8 +119,10 @@ impl Connection {
     /// Load all the previously stored crawler checkpoints from the database.
     /// # Arguments
     pub fn load_checkpoints(&self) -> Result<Vec<CrawlerCheckpoint>> {
-        let mut stmt =
-            self.prepare("SELECT room_id, token, full_crawl, direction FROM crawlercheckpoints")?;
+        let mut stmt = self.prepare(
+            "SELECT room_id, token, full_crawl, direction
+                                    FROM crawlercheckpoints",
+        )?;
 
         let rows = stmt.query_map(NO_PARAMS, |row| {
             Ok(CrawlerCheckpoint {
@@ -874,8 +876,8 @@ impl Database {
     ) -> Result<()> {
         if let Some(checkpoint) = new {
             connection.execute(
-                "INSERT OR IGNORE INTO crawlercheckpoints (room_id, token, full_crawl, direction)
-                VALUES(?1, ?2, ?3, ?4)",
+                "INSERT OR IGNORE INTO crawlercheckpoints
+                (room_id, token, full_crawl, direction) VALUES(?1, ?2, ?3, ?4)",
                 &[
                     &checkpoint.room_id,
                     &checkpoint.token,
@@ -1175,7 +1177,7 @@ fn is_empty() {
     assert!(connection.is_empty().unwrap());
 
     let profile = Profile::new("Alice", "");
-    db.add_event(EVENT.clone(), profile.clone());
+    db.add_event(EVENT.clone(), profile);
     db.commit().unwrap();
     assert!(!connection.is_empty().unwrap());
 }
@@ -1200,7 +1202,7 @@ fn encrypted_db() {
     );
 
     let profile = Profile::new("Alice", "");
-    db.add_event(EVENT.clone(), profile.clone());
+    db.add_event(EVENT.clone(), profile);
 
     match db.commit() {
         Ok(_) => (),
@@ -1238,7 +1240,7 @@ fn change_passphrase() {
     );
 
     let profile = Profile::new("Alice", "");
-    db.add_event(EVENT.clone(), profile.clone());
+    db.add_event(EVENT.clone(), profile);
 
     db.commit().expect("Could not commit events to database");
     db.change_passphrase("wordpass")

--- a/src/database.rs
+++ b/src/database.rs
@@ -528,6 +528,11 @@ impl Database {
             NO_PARAMS,
         )?;
 
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS room_events ON events (room_id, type, msgtype)",
+            NO_PARAMS,
+        )?;
+
         Ok(())
     }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -494,6 +494,7 @@ impl Database {
                 room_id TEXT NOT NULL,
                 content_value TEXT NOT NULL,
                 type TEXT NOT NULL,
+                msgtype TEXT,
                 source TEXT NOT NULL,
                 profile_id INTEGER NOT NULL,
                 FOREIGN KEY (profile_id) REFERENCES profile (id),
@@ -592,8 +593,8 @@ impl Database {
             "
             INSERT OR IGNORE INTO events (
                 event_id, sender, server_ts, room_id, content_value, type,
-                source, profile_id
-            ) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+                msgtype, source, profile_id
+            ) VALUES(?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9)",
             &[
                 &event.event_id,
                 &event.sender,
@@ -601,6 +602,7 @@ impl Database {
                 &event.room_id,
                 &event.content_value,
                 &event.event_type as &dyn ToSql,
+                &event.msgtype,
                 &event.source,
                 &profile_id as &dyn ToSql,
             ],
@@ -757,7 +759,8 @@ impl Database {
 
         let mut stmt = if order_by_recency {
             connection.prepare(&format!(
-                "SELECT type, content_value, event_id, sender, server_ts, room_id, source, displayname, avatar_url
+                "SELECT type, content_value, msgtype, event_id, sender,
+                 server_ts, room_id, source, displayname, avatar_url
                  FROM events
                  INNER JOIN profiles on profiles.id = events.profile_id
                  WHERE event_id IN (?{})
@@ -767,7 +770,8 @@ impl Database {
             ))?
         } else {
             connection.prepare(&format!(
-                "SELECT type, content_value, event_id, sender, server_ts, room_id, source, displayname, avatar_url
+                "SELECT type, content_value, msgtype, event_id, sender,
+                 server_ts, room_id, source, displayname, avatar_url
                  FROM events
                  INNER JOIN profiles on profiles.id = events.profile_id
                  WHERE event_id IN (?{})
@@ -792,15 +796,16 @@ impl Database {
                 Event {
                     event_type: row.get(0)?,
                     content_value: row.get(1)?,
-                    event_id: row.get(2)?,
-                    sender: row.get(3)?,
-                    server_ts: row.get(4)?,
-                    room_id: row.get(5)?,
-                    source: row.get(6)?,
+                    msgtype: row.get(2)?,
+                    event_id: row.get(3)?,
+                    sender: row.get(4)?,
+                    server_ts: row.get(5)?,
+                    room_id: row.get(6)?,
+                    source: row.get(7)?,
                 },
                 Profile {
-                    displayname: row.get(7)?,
-                    avatar_url: row.get(8)?,
+                    displayname: row.get(8)?,
+                    avatar_url: row.get(9)?,
                 },
             ))
         })?;

--- a/src/database.rs
+++ b/src/database.rs
@@ -81,6 +81,10 @@ impl Searcher {
     /// # Arguments
     ///
     /// * `term` - The search term that should be used to search the index.
+    /// * `config` - A SearchConfig that will modify what the search result
+    /// should contain.
+    ///
+    /// Returns a list of `SearchResult`.
     pub fn search(&self, term: &str, config: &SearchConfig) -> Result<Vec<SearchResult>> {
         let search_result = self.inner.search(term, config)?;
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -688,6 +688,7 @@ impl Database {
                      FROM events
                      WHERE (
                          (room_id == ?1) &
+                         (type == 'm.room.message') &
                          (msgtype in ({})) &
                          (event_id != ?2) &
                          (server_ts <= ?3)
@@ -719,6 +720,7 @@ impl Database {
                      FROM events
                      WHERE (
                          (room_id == ?1) &
+                         (type == 'm.room.message') &
                          (msgtype in ({}))
                      ) ORDER BY server_ts DESC LIMIT ?2
                      ",

--- a/src/database.rs
+++ b/src/database.rs
@@ -100,26 +100,6 @@ impl Searcher {
             config.order_by_recency,
         )?)
     }
-
-    /// Get events that contain an mxc URL to a file.
-    /// # Arguments
-    ///
-    /// * `room_id` - The ID of the room for which the events should be loaded.
-    /// * `limit` - The maximum number of events to return.
-    /// * `from_event` - An event id of a previous event returned by this
-    ///     method.  If set events that are older than the event with the given
-    ///     event ID will be returned.
-    ///
-    /// Returns a list of serialized events.
-    pub fn get_file_events(
-        &self,
-        room_id: &str,
-        limit: u32,
-        from_event: Option<&str>,
-    ) -> Result<Vec<SerializedEvent>> {
-        let ret = Database::load_file_events(&self.database, room_id, limit, from_event)?;
-        Ok(ret)
-    }
 }
 
 unsafe impl Send for Searcher {}
@@ -179,6 +159,26 @@ impl Connection {
         )?;
 
         Ok(event_count == 0 && checkpoint_count == 0)
+    }
+
+    /// Get events that contain an mxc URL to a file.
+    /// # Arguments
+    ///
+    /// * `room_id` - The ID of the room for which the events should be loaded.
+    /// * `limit` - The maximum number of events to return.
+    /// * `from_event` - An event id of a previous event returned by this
+    ///     method.  If set events that are older than the event with the given
+    ///     event ID will be returned.
+    ///
+    /// Returns a list of serialized events.
+    pub fn get_file_events(
+        &self,
+        room_id: &str,
+        limit: u32,
+        from_event: Option<&str>,
+    ) -> Result<Vec<SerializedEvent>> {
+        let ret = Database::load_file_events(self, room_id, limit, from_event)?;
+        Ok(ret)
     }
 }
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -1024,7 +1024,7 @@ impl Database {
 
     /// Get a database connection.
     /// Note that this connection should only be used for reading.
-    pub fn get_connection(&mut self) -> Result<Connection> {
+    pub fn get_connection(&self) -> Result<Connection> {
         let connection = self.pool.get()?;
 
         if let Some(ref p) = self.passphrase {
@@ -1219,7 +1219,7 @@ fn load_event_context() {
 #[test]
 fn save_and_load_checkpoints() {
     let tmpdir = tempdir().unwrap();
-    let mut db = Database::new(tmpdir.path()).unwrap();
+    let db = Database::new(tmpdir.path()).unwrap();
 
     let checkpoint = CrawlerCheckpoint {
         room_id: "!test:room".to_string(),
@@ -1366,7 +1366,7 @@ fn change_passphrase() {
         .expect("Could not change the database passphrase");
 
     let db_config = Config::new().set_passphrase("wordpass");
-    let mut db = Database::new_with_config(tmpdir.path(), &db_config)
+    let db = Database::new_with_config(tmpdir.path(), &db_config)
         .expect("Could not open database with the new passphrase");
     let connection = db
         .get_connection()

--- a/src/events.rs
+++ b/src/events.rs
@@ -87,6 +87,8 @@ pub struct Event {
     /// The textual representation of a message, this part of the event will be
     /// indexed.
     pub content_value: String,
+    /// The type of the message if the event is of a m.room.text type.
+    pub msgtype: Option<String>,
     /// The unique identifier of this event.
     pub event_id: String,
     /// The MXID of the user who sent this event.
@@ -108,6 +110,7 @@ impl<T> Dummy<T> for Event {
         Event::new(
             EventType::Message,
             "Hello world",
+            Some("m.text"),
             &format!("${}:{}", (0..10).fake::<u8>(), &domain),
             &format!(
                 "@{}:{}",
@@ -155,15 +158,23 @@ impl Event {
     pub fn new(
         event_type: EventType,
         content_value: &str,
+        msgtype: Option<&str>,
         event_id: &str,
         sender: &str,
         server_ts: i64,
         room_id: &str,
         source: &str,
     ) -> Event {
+        let msgtype = if let Some(m) = msgtype {
+            Some(m.to_string())
+        } else {
+            None
+        };
+
         Event {
-            event_type: event_type.clone(),
+            event_type,
             content_value: content_value.to_string(),
+            msgtype,
             event_id: event_id.to_string(),
             sender: sender.to_string(),
             server_ts,
@@ -229,11 +240,12 @@ lazy_static! {
     pub static ref EVENT: Event = Event::new(
         EventType::Message,
         "Test message",
+        Some("m.text"),
         "$15163622445EBvZJ:localhost",
         "@example2:localhost",
         151636_2244026,
         "!test_room:localhost",
-        EVENT_SOURCE
+        EVENT_SOURCE,
     );
 }
 
@@ -242,11 +254,12 @@ lazy_static! {
     pub static ref TOPIC_EVENT: Event = Event::new(
         EventType::Topic,
         "Test topic",
+        None,
         "$15163622445EBvZE:localhost",
         "@example2:localhost",
         151636_2244038,
         "!test_room:localhost",
-        TOPIC_EVENT_SOURCE
+        TOPIC_EVENT_SOURCE,
     );
 }
 
@@ -256,20 +269,22 @@ lazy_static! {
         Event::new(
             EventType::Message,
             "日本語の本文",
+            Some("m.text"),
             "$15163622445EBvZE:localhost",
             "@example2:localhost",
             151636_2244038,
             "!test_room:localhost",
-            ""
+            "",
         ),
         Event::new(
             EventType::Message,
             "ルダの伝説 時のオカリナ",
+            Some("m.text"),
             "$15163622445ZERuD:localhost",
             "@example2:localhost",
             151636_2244063,
             "!test_room:localhost",
-            ""
+            "",
         ),
     ];
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -179,7 +179,7 @@ fn duplicate_events() {
 #[test]
 fn save_and_search_historic_events() {
     let tmpdir = tempdir().unwrap();
-    let mut db = Database::new(tmpdir.path()).unwrap();
+    let db = Database::new(tmpdir.path()).unwrap();
     let profile = Profile::new("Alice", "");
 
     let mut events = Vec::new();

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -112,7 +112,7 @@ fn duplicate_events() {
     let profile = Profile::new("Alice", "");
 
     db.add_event(EVENT.clone(), profile.clone());
-    db.add_event(EVENT.clone(), profile.clone());
+    db.add_event(EVENT.clone(), profile);
 
     db.commit().unwrap();
     db.reload().unwrap();
@@ -186,7 +186,7 @@ fn add_differing_events() {
     let profile = Profile::new("Alice", "");
 
     db.add_event(EVENT.clone(), profile.clone());
-    db.add_event(TOPIC_EVENT.clone(), profile.clone());
+    db.add_event(TOPIC_EVENT.clone(), profile);
     db.commit().unwrap();
     db.reload().unwrap();
 
@@ -211,7 +211,7 @@ fn search_with_specific_key() {
         .unwrap();
     assert!(result.is_empty());
 
-    db.add_event(TOPIC_EVENT.clone(), profile.clone());
+    db.add_event(TOPIC_EVENT.clone(), profile);
     db.commit().unwrap();
     db.reload().unwrap();
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -318,9 +318,9 @@ fn load_file_events() {
     db.commit().unwrap();
     db.reload().unwrap();
 
-    let searcher = db.get_searcher();
+    let connection = db.get_connection().unwrap();
 
-    let result = searcher
+    let result = connection
         .get_file_events(&FILE_EVENT.room_id, 10, None)
         .expect("Can't load file events");
     assert!(!result.is_empty());
@@ -329,14 +329,14 @@ fn load_file_events() {
     assert!(result.len() == 2);
     assert_eq!(result[1], FILE_EVENT.source);
 
-    let result = searcher
+    let result = connection
         .get_file_events(&FILE_EVENT.room_id, 1, None)
         .expect("Can't load file events");
     assert!(!result.is_empty());
     assert!(result.len() == 1);
     assert_eq!(result[0], IMAGE_EVENT.source);
 
-    let result = searcher
+    let result = connection
         .get_file_events(&FILE_EVENT.room_id, 1, Some(&IMAGE_EVENT.event_id))
         .expect("Can't load file events with token");
 

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -43,11 +43,12 @@ lazy_static! {
     pub static ref EVENT: Event = Event::new(
         EventType::Message,
         "Test message",
+        Some("m.text"),
         "$15163622445EBvZJ:localhost",
         "@example2:localhost",
         151636_2244026,
         "!test_room:localhost",
-        EVENT_SOURCE
+        EVENT_SOURCE,
     );
 }
 
@@ -55,11 +56,12 @@ lazy_static! {
     pub static ref TOPIC_EVENT: Event = Event::new(
         EventType::Topic,
         "Test topic",
+        None,
         "$15163622445EBvZE:localhost",
         "@example2:localhost",
         151636_2244038,
         "!test_room:localhost",
-        TOPIC_EVENT_SOURCE
+        TOPIC_EVENT_SOURCE,
     );
 }
 
@@ -69,6 +71,7 @@ fn fake_event() -> Event {
     Event::new(
         EventType::Message,
         "Hello world",
+        Some("m.text"),
         &format!("${}:{}", (0..10).fake::<u8>(), &domain),
         &format!(
             "@{}:{}",


### PR DESCRIPTION
This patch-set adds the ability to fetch events containing URLs, or events that contain files, from the database easily.

The feature will be useful for clients to quickly show uploaded files files inside of encrypted rooms (e.g. the file panel in riot).

Since those events are of the `m.room.message` type but contain differing `msgtype` values inside of their content the database schema is changed to store the `msgtype` with the event.

The feature may be enhanced at a later state to support exporting all the events, not just file based events, from the database.