### PR TITLE
Reader readonly source

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "Apache-2.0"
 description = "A matrix message logger with full text search support"
 
 [dependencies]
-tantivy = { git = "https://github.com/tantivy-search/tantivy", rev = "598b076" }
+tantivy = { git = "https://github.com/matrix-org/tantivy", branch = "reader_readonly_source" }
 tinysegmenter = "0.1"
 rusqlite = { version = "0.20", features = ["sqlcipher"] }
 fs_extra = "1.1.0"


### PR DESCRIPTION
This PR implements lazy decryption for the `open_read()` implementation of the EncryptedMmapDirectory implementation that is used to encrypt the Tantivy index files. The `EncryptedMmapDirectory` implements the Tantivy [Directory](https://docs.rs/tantivy/0.11.3/tantivy/trait.Directory.html) trait. The `open_read()` method of this trait needs to return a [ReadOnlySource](https://docs.rs/tantivy/0.11.3/tantivy/directory/struct.ReadOnlySource.html) which is the way Tantivy accesses all its indexer files.

The problem with the current `ReadOnlySource` for the encrypted directory implementation is that it requires direct access to an array, or a type that has the following trait bound `Deref<Target = [u8]>`. Adding the decryption logic to array access isn't possible so the current implementation of the encrypted directory kept the decrypted file in memory.

To mitigate this the ReadOnlySource API was changed to use the common `Read` + `Seek` traits. This way we can add the decryption logic to the `read()` calls. The `Seek` trait is necessary because Tantivy likes to keep around differing views of a file around or just to jump around in the file for example if the file contains a skip-list.

The bulk of the changes for Tantivy can be found [here](https://github.com/matrix-org/tantivy/tree/reader_readonly_source)

A [PR](https://github.com/tantivy-search/tantivy/pull/737) has been opened upstream for this patch-set, sadly upstream doesn't have the time to work on this with us.

This intends to fix #21.

It would be nice if this patch could be tested in real world scenarios to confirm that it indeed helps with the memory usage and doesn't just shuffle the allocations around. If the problem persists a likely suspect for it is ordering Tantivy to commit too often, which ends up spawning threads that try to merge index segments. If those can't merge the segments before the next commit a runaway situation occurs which likely looks like a leak.