### PR TITLE
Tantivy flow control

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,43 +1,49 @@
-matrix:
+jobs:
   allow_failures:
     - os: windows
   include:
+
     - os: linux
       dist: bionic
       language: rust
+      before_install:
+          - sudo apt-get update -q
+          - sudo apt-get install libsqlcipher-dev -y
+          - nvm install $TRAVIS_NODE_VERSION
+          - nvm use ${TRAVIS_NODE_VERSION}
       env:
         - TRAVIS_NODE_VERSION="12"
+
     - os: osx
       language: rust
+      before_install:
+          - HOMEBREW_NO_AUTO_UPDATE=1 brew install sqlcipher
+          - nvm install $TRAVIS_NODE_VERSION
+          - nvm use ${TRAVIS_NODE_VERSION}
+      script:
+          - cargo test -- --test-threads=1
+          - cd seshat-node
+          - yarn install
+          - yarn test --timeout 4000
+          - yarn lint
       env:
         - TRAVIS_NODE_VERSION="12"
+
     - os: windows
       language: rust
+      before_install:
+          - git clone --single-branch https://github.com/jasongin/nvs $NVS_HOME
+          - source $NVS_HOME/nvs.sh
+          - nvs --version
+          - nvs add $TRAVIS_NODE_VERSION && nvs use $TRAVIS_NODE_VERSION
+          - choco install sqlite
       env:
         - TRAVIS_NODE_VERSION="12"
+        - NVS_HOME=$ProgramData/nvs
 
 cache: cargo
 
-before_install:
-  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then
-    export NVS_HOME=$ProgramData/nvs;
-    git clone --single-branch https://github.com/jasongin/nvs $NVS_HOME;
-    source $NVS_HOME/nvs.sh;
-    nvs --version;
-    nvs add $TRAVIS_NODE_VERSION && nvs use $TRAVIS_NODE_VERSION;
-    choco install sqlite;
-    cd C:\ProgramData\chocolatey\lib\SQLite\tools;
-    lib /def:sqlite3.def /out:sqlite3.lib;
-    elif [[ "$TRAVIS_OS_NAME" == "osx" ]] ; then
-    HOMEBREW_NO_AUTO_UPDATE=1 brew install sqlcipher;
-    nvm install $TRAVIS_NODE_VERSION;
-    nvm use ${TRAVIS_NODE_VERSION};
-    else
-    sudo apt-get update -q;
-    sudo apt-get install libsqlcipher-dev -y;
-    nvm install $TRAVIS_NODE_VERSION;
-    nvm use ${TRAVIS_NODE_VERSION};
-    fi
+install:
   - node -v
   - npm -v
   - npm i -g yarn@latest neon-cli@latest

--- a/seshat-node/lib/index.js
+++ b/seshat-node/lib/index.js
@@ -112,12 +112,17 @@ class Seshat extends seshat.Seshat {
      * This is the asynchronous equivalent of the <code>commitSync()</code>
      * method.
      *
+     * @param  {boolean} force Force the commit, commits to the index are
+     * usually rate limited. This gets around the limit and forces the
+     * documents to be added to the index. This should only be used for testing
+     * purposes.
+     *
      * @return {Promise<number>} The latest stamp of the commit. The stamp is
      * a unique incrementing number that identifies the commit.
      */
-    async commit() {
+    async commit(force = false) {
         return new Promise((resolve, reject) => {
-            super.commit((err, res) => {
+            super.commit(force, (err, res) => {
                 resolve(res);
             });
         });
@@ -126,14 +131,18 @@ class Seshat extends seshat.Seshat {
     /**
      * Commit the queued up events to the database.
      *
-     * @param  {boolean} wait Wait for the events to be commited. If true will
-     * block until the events are commited.
+     * @param  {boolean} wait Wait for the events to be committed. If true will
+     * block until the events are committed.
+     * @param  {boolean} force Force the commit, commits to the index are
+     * usually rate limited. This gets around the limit and forces the
+     * documents to be added to the index. This should only be used for testing
+     * purposes.
      *
      * @return {number} The latest stamp of the commit. The stamp is a unique
      * incrementing number that identifies the commit.
      */
-    commitSync(wait = false) {
-        return super.commitSync(wait);
+    commitSync(wait = false, force = false) {
+        return super.commitSync(wait, force);
     }
 
     /**

--- a/seshat-node/test/test.js
+++ b/seshat-node/test/test.js
@@ -160,7 +160,7 @@ describe('Database', function() {
 
     it('should allow events to be commited', function() {
         const db = createDb();
-        db.commitSync(true);
+        db.commitSync(true, true);
 
         ret = db.commitSync(false);
         assert.equal(ret, undefined);
@@ -171,14 +171,14 @@ describe('Database', function() {
 
     it('should allow events to be commited using a promise', async function() {
         const db = createDb();
-        await db.commit();
+        await db.commit(true);
     });
 
     it('should return a search result for the stored event', async function() {
         const db = createDb();
         db.addEvent(matrixEvent);
 
-        await db.commit();
+        await db.commit(true);
         db.reload();
 
         const results = db.searchSync({search_term:'Test'});
@@ -190,7 +190,7 @@ describe('Database', function() {
         const db = createDb();
         db.addEvent(matrixEvent, matrixProfileOnlyDisplayName);
 
-        await db.commit();
+        await db.commit(true);
         db.reload();
 
         const results = await db.search({search_term: 'Test'});
@@ -235,7 +235,7 @@ describe('Database', function() {
         db.addEvent(matrixEvent, matrixProfileOnlyDisplayName);
         db.addEvent(matrixEventRoom2, matrixProfileOnlyDisplayName);
 
-        await db.commit();
+        await db.commit(true);
         db.reload();
 
         const results = await db.search({
@@ -252,7 +252,7 @@ describe('Database', function() {
         db.addEvent(laterMatrixEvent, matrixProfileOnlyDisplayName);
         db.addEvent(beforeMatrixEvent, matrixProfileOnlyDisplayName);
 
-        await db.commit();
+        await db.commit(true);
         db.reload();
 
         const results = await db.search({
@@ -271,7 +271,7 @@ describe('Database', function() {
         db.addEvent(laterMatrixEvent, matrixProfileOnlyDisplayName);
         db.addEvent(beforeMatrixEvent, matrixProfileOnlyDisplayName);
 
-        await db.commit();
+        await db.commit(true);
         db.reload();
 
         const results = await db.search({search_term: 'Test'});
@@ -285,7 +285,7 @@ describe('Database', function() {
         db.addEvent(matrixEvent, matrixProfileOnlyDisplayName);
         db.addEvent(matrixEventRoom2, matrixProfileOnlyDisplayName);
 
-        await db.commit();
+        await db.commit(true);
         let size = await db.getSize();
         assert.isAbove(size, 0)
     });
@@ -296,7 +296,7 @@ describe('Database', function() {
         db.addEvent(topicEvent, matrixProfileOnlyDisplayName);
         db.addEvent(nameEvent, matrixProfileOnlyDisplayName);
 
-        await db.commit();
+        await db.commit(true);
         db.reload();
     });
 
@@ -304,7 +304,7 @@ describe('Database', function() {
         const db = createDb();
         db.addEvent(matrixEvent, matrixProfileOnlyDisplayName);
 
-        await db.commit();
+        await db.commit(true);
         db.reload();
 
         let results = await db.search({
@@ -314,7 +314,7 @@ describe('Database', function() {
         assert.equal(results.count, 0);
 
         db.addEvent(topicEvent);
-        await db.commit();
+        await db.commit(true);
         db.reload();
 
         results = await db.search({
@@ -337,7 +337,7 @@ describe('Database', function() {
         const db = new Seshat(tempDir, {language: "german"});
 
         db.addEvent(matrixEvent, matrixProfileOnlyDisplayName);
-        await db.commit();
+        await db.commit(true);
         db.reload();
 
         results = await db.search({
@@ -351,7 +351,7 @@ describe('Database', function() {
         db.addEvent(matrixEvent, matrixProfileOnlyDisplayName);
 
         db.addEvent(matrixEvent, matrixProfileOnlyDisplayName);
-        await db.commit();
+        await db.commit(true);
         db.reload();
 
         await db.delete()
@@ -364,7 +364,7 @@ describe('Database', function() {
         assert(await db.isEmpty());
 
         db.addEvent(matrixEvent, matrixProfileOnlyDisplayName);
-        await db.commit();
+        await db.commit(true);
 
         assert(!await db.isEmpty());
     });
@@ -375,7 +375,7 @@ describe('Database', function() {
 
         assert(await db.isEmpty());
         db.addEvent(matrixEvent, matrixProfileOnlyDisplayName);
-        await db.commit();
+        await db.commit(true);
         assert(!await db.isEmpty());
 
         expect(() => db = new Seshat(tempDir)).to.throw('');
@@ -387,7 +387,7 @@ describe('Database', function() {
         db.addEvent(fileEvent, matrixProfileOnlyDisplayName);
         db.addEvent(imageEvent, matrixProfileOnlyDisplayName);
 
-        await db.commit();
+        await db.commit(true);
         let events = await db.getFileEvents({roomId: fileEvent.room_id, limit: 10})
         assert(events.length == 2);
 

--- a/src/database.rs
+++ b/src/database.rs
@@ -561,7 +561,15 @@ impl Database {
         self.commit_helper(false).recv().unwrap()
     }
 
-    /// Force a commit.
+    /// Commit the currently queued up events forcing the commit to the index.
+    ///
+    /// Commits are usually rate limited. This gets around the limit and forces
+    /// the documents to be added to the index.
+    ///
+    /// This method will block. A non-blocking version of this method exists in
+    /// the `force_commit_no_wait()` method.
+    ///
+    /// This should only be used for testing purposes.
     pub fn force_commit(&mut self) -> Result<()> {
         self.commit_helper(true).recv().unwrap()
     }
@@ -576,8 +584,24 @@ impl Database {
 
     /// Commit the currently queued up events without waiting for confirmation
     /// that the operation is done.
+    ///
+    /// Returns a receiver that will receive an empty message once the commit is
+    /// done.
     pub fn commit_no_wait(&mut self) -> Receiver<Result<()>> {
         self.commit_helper(false)
+    }
+
+    /// Commit the currently queued up events forcing the commit to the index.
+    ///
+    /// Commits are usually rate limited. This gets around the limit and forces
+    /// the documents to be added to the index.
+    ///
+    /// This should only be used for testing purposes.
+    ///
+    /// Returns a receiver that will receive an empty message once the commit is
+    /// done.
+    pub fn force_commit_no_wait(&mut self) -> Receiver<Result<()>> {
+        self.commit_helper(true)
     }
 
     /// Add the given events from the room history to the database.

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -151,7 +151,7 @@ fn save_and_search() {
     let profile = Profile::new("Alice", "");
 
     db.add_event(EVENT.clone(), profile);
-    db.commit().unwrap();
+    db.force_commit().unwrap();
     db.reload().unwrap();
 
     let result = db.search("Test", &Default::default()).unwrap();
@@ -168,7 +168,7 @@ fn duplicate_events() {
     db.add_event(EVENT.clone(), profile.clone());
     db.add_event(EVENT.clone(), profile);
 
-    db.commit().unwrap();
+    db.force_commit().unwrap();
     db.reload().unwrap();
 
     let searcher = db.get_searcher();
@@ -229,7 +229,7 @@ fn get_size() {
 
         db.add_event(event, profile.clone());
     }
-    db.commit().unwrap();
+    db.force_commit().unwrap();
     assert!(db.get_size().unwrap() > 0);
 }
 
@@ -241,7 +241,7 @@ fn add_differing_events() {
 
     db.add_event(EVENT.clone(), profile.clone());
     db.add_event(TOPIC_EVENT.clone(), profile);
-    db.commit().unwrap();
+    db.force_commit().unwrap();
     db.reload().unwrap();
 
     let searcher = db.get_searcher();
@@ -257,7 +257,7 @@ fn search_with_specific_key() {
     let searcher = db.get_searcher();
 
     db.add_event(EVENT.clone(), profile.clone());
-    db.commit().unwrap();
+    db.force_commit().unwrap();
     db.reload().unwrap();
 
     let result = searcher
@@ -266,7 +266,7 @@ fn search_with_specific_key() {
     assert!(result.is_empty());
 
     db.add_event(TOPIC_EVENT.clone(), profile);
-    db.commit().unwrap();
+    db.force_commit().unwrap();
     db.reload().unwrap();
 
     let searcher = db.get_searcher();
@@ -298,7 +298,7 @@ fn encrypted_save_and_search() {
     let profile = Profile::new("Alice", "");
 
     db.add_event(EVENT.clone(), profile);
-    db.commit().unwrap();
+    db.force_commit().unwrap();
     db.reload().unwrap();
 
     let result = db.search("Test", &Default::default()).unwrap();
@@ -315,7 +315,7 @@ fn load_file_events() {
     db.add_event(EVENT.clone(), profile.clone());
     db.add_event(FILE_EVENT.clone(), profile.clone());
     db.add_event(IMAGE_EVENT.clone(), profile);
-    db.commit().unwrap();
+    db.force_commit().unwrap();
     db.reload().unwrap();
 
     let connection = db.get_connection().unwrap();


### PR DESCRIPTION
Tantivy doesn't behave nicely if commit() is called too often on the index writer. A commit means that Tantivy will spawn threads that will try to merge index segments together, that is, it tries to merge a bunch smaller files into one larger.

If users call commit faster than those threads manage to merge the segments, the number of spawned threads keeps on increasing.

This patch limits the number of commit calls we forward to the index writer. To avoid data loss we mark the uncommitted events as such in the database and restore them if needed after a new database object is created.

The PR includes an example binary that can be used to check the behavior of Seshat using differing event counts and  commit rates.

The validity of the patch has been checked using Heaptrack and this example. The following graphs were done using 100000 events and a commit rate of 10:

    cargo run --example database 1000000 10

![Memory usage before the patch.](https://user-images.githubusercontent.com/552026/72267425-56b86580-3620-11ea-907d-6cf1b540b906.png)
Before the patch was applied.


![Memory usage after the patch.](https://user-images.githubusercontent.com/552026/72267502-764f8e00-3620-11ea-9296-7b28f4c717be.png)
After the patch was applied.