### PR TITLE
Load file events improvements

### DIFF
--- a/seshat-node/lib/index.js
+++ b/seshat-node/lib/index.js
@@ -350,6 +350,9 @@ class Seshat extends seshat.Seshat {
      * @param  {string} args.fromEvent An event id of a previous event returned
      * by this method. If set events that are older than the event with the
      * given event ID will be returned.
+     * @param {string} args.direction The direction that we are going to
+     * continue lading events to. Can be either "backwards", "b", "forwards" or
+     * "f".
      *
      * @return {Promise<[loadResult]>} A promise that will resolve to an array
      * of Matrix events that contain mxc URLs.

--- a/seshat-node/lib/index.js
+++ b/seshat-node/lib/index.js
@@ -57,6 +57,13 @@ const seshat = require('../native');
  * one of "b" or "f".
  */
 
+/**
+ * @typedef loadResult
+ * @type {Object}
+ * @property {matrixEvent} event A matrix event that was loaded from the database.
+ * @property {matrixProfile} profile The profile of the sender at the time the
+ * event was sent.
+ */
 
 /**
  * Seshat database.<br>
@@ -334,7 +341,7 @@ class Seshat extends seshat.Seshat {
     }
 
     /**
-     * Get events that contain an mxc URL to a file.
+     * Load events that contain an mxc URL to a file.
      *
      * @param  {object} args Arguments object for the method.
      * @param  {string} args.roomId The ID of the room for which the events
@@ -344,12 +351,12 @@ class Seshat extends seshat.Seshat {
      * by this method. If set events that are older than the event with the
      * given event ID will be returned.
      *
-     * @return {Promise<[matrixEvent]>} A promise that will resolve to an array
+     * @return {Promise<[loadResult]>} A promise that will resolve to an array
      * of Matrix events that contain mxc URLs.
      */
-    async getFileEvents(args) {
+    async loadFileEvents(args) {
         return new Promise((resolve, reject) => {
-            super.getFileEvents(args, (err, res) => {
+            super.loadFileEvents(args, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });

--- a/seshat-node/lib/index.js
+++ b/seshat-node/lib/index.js
@@ -60,7 +60,8 @@ const seshat = require('../native');
 /**
  * @typedef loadResult
  * @type {Object}
- * @property {matrixEvent} event A matrix event that was loaded from the database.
+ * @property {matrixEvent} event A matrix event that was loaded from the
+ * database.
  * @property {matrixProfile} profile The profile of the sender at the time the
  * event was sent.
  */

--- a/seshat-node/native/src/lib.rs
+++ b/seshat-node/native/src/lib.rs
@@ -20,7 +20,7 @@ use neon_serde;
 use serde_json;
 use seshat::{
     CheckpointDirection, Config, Connection, CrawlerCheckpoint, Database, Event, EventType,
-    Language, LoadConfig, Profile, Receiver, SearchConfig, SearchResult, Searcher,
+    Language, LoadConfig, LoadDirection, Profile, Receiver, SearchConfig, SearchResult, Searcher,
 };
 
 #[no_mangle]
@@ -661,6 +661,19 @@ declare_types! {
                     config = config.from_event(e.value());
                 }
             };
+
+            if let Ok(d) = args.get(&mut cx, "direction") {
+                if let Ok(e) = d.downcast::<JsString>() {
+                    let direction = match e.value().to_lowercase().as_ref() {
+                        "backwards" | "backward" | "b" => LoadDirection::Backwards,
+                        "forwards" | "forward" | "f" => LoadDirection::Forwards,
+                        "" => LoadDirection::Backwards,
+                        d => return cx.throw_error(format!("Unknown load direction {}", d)),
+                    };
+
+                    config = config.direction(direction);
+                }
+            }
 
             let mut this = cx.this();
 

--- a/seshat-node/test/test.js
+++ b/seshat-node/test/test.js
@@ -388,16 +388,16 @@ describe('Database', function() {
         db.addEvent(imageEvent, matrixProfileOnlyDisplayName);
 
         await db.commit(true);
-        let events = await db.getFileEvents({roomId: fileEvent.room_id, limit: 10})
+        let events = await db.loadFileEvents({roomId: fileEvent.room_id, limit: 10})
         assert(events.length == 2);
 
-        events = await db.getFileEvents({roomId: fileEvent.room_id, limit: 1})
+        events = await db.loadFileEvents({roomId: fileEvent.room_id, limit: 1})
         assert(events.length == 1);
-        assert.deepEqual(events[0], imageEvent);
+        assert.deepEqual(events[0].event, imageEvent);
 
-        events = await db.getFileEvents({roomId: fileEvent.room_id, limit: 10, fromEvent: imageEvent.event_id})
+        events = await db.loadFileEvents({roomId: fileEvent.room_id, limit: 10, fromEvent: imageEvent.event_id})
         assert(events.length == 1);
-        assert.deepEqual(events[0], fileEvent);
+        assert.deepEqual(events[0].event, fileEvent);
     });
 
     it('should throw an error when adding events with missing fields.', function() {

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,8 @@ use zeroize::Zeroizing;
 
 use crate::events::{EventType, RoomId};
 
+const DEFAULT_LOAD_LIMIT: usize = 20;
+
 #[derive(Debug, PartialEq, Clone)]
 /// Search configuration
 /// A search configuration allows users to limit the search to a specific room
@@ -243,5 +245,32 @@ impl Default for Config {
             language: Language::Unknown,
             passphrase: None,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LoadConfig {
+    pub(crate) room_id: String,
+    pub(crate) limit: usize,
+    pub(crate) from_event: Option<String>,
+}
+
+impl LoadConfig {
+    pub fn new<R: Into<String>>(room_id: R) -> Self {
+        LoadConfig {
+            room_id: room_id.into(),
+            limit: DEFAULT_LOAD_LIMIT,
+            from_event: None,
+        }
+    }
+
+    pub fn limit(mut self, limit: usize) -> Self {
+        self.limit = limit;
+        self
+    }
+
+    pub fn from_event<E: Into<String>>(mut self, event_id: E) -> Self {
+        self.from_event = Some(event_id.into());
+        self
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -248,6 +248,12 @@ impl Default for Config {
     }
 }
 
+#[derive(Debug, Clone)]
+pub enum LoadDirection {
+    Backwards,
+    Forwards,
+}
+
 /// Configuration for the event loading methods.
 ///
 /// A load configuration allows users to limit the number of events that will be
@@ -258,6 +264,7 @@ pub struct LoadConfig {
     pub(crate) room_id: String,
     pub(crate) limit: usize,
     pub(crate) from_event: Option<String>,
+    pub(crate) direction: LoadDirection,
 }
 
 impl LoadConfig {
@@ -273,6 +280,7 @@ impl LoadConfig {
             room_id: room_id.into(),
             limit: DEFAULT_LOAD_LIMIT,
             from_event: None,
+            direction: LoadDirection::Backwards,
         }
     }
 
@@ -295,6 +303,11 @@ impl LoadConfig {
     /// event ID will be returned.
     pub fn from_event<E: Into<String>>(mut self, event_id: E) -> Self {
         self.from_event = Some(event_id.into());
+        self
+    }
+
+    pub fn direction(mut self, direction: LoadDirection) -> Self {
+        self.direction = direction;
         self
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -248,6 +248,11 @@ impl Default for Config {
     }
 }
 
+/// Configuration for the event loading methods.
+///
+/// A load configuration allows users to limit the number of events that will be
+/// loaded or to continue loading events from a specific point in the room
+/// history.
 #[derive(Debug, Clone)]
 pub struct LoadConfig {
     pub(crate) room_id: String,
@@ -256,6 +261,13 @@ pub struct LoadConfig {
 }
 
 impl LoadConfig {
+    /// Create a new LoadConfig
+    ///
+    /// The config will be created with a default limit of 20 events.
+    ///
+    /// # Arguments
+    ///
+    /// * `room_id` - The room from which to load the events.
     pub fn new<R: Into<String>>(room_id: R) -> Self {
         LoadConfig {
             room_id: room_id.into(),
@@ -264,11 +276,23 @@ impl LoadConfig {
         }
     }
 
+    /// Set the maximum amount of events that we want to load.
+    /// # Arguments
+    ///
+    /// * `limit` - The new limit that should be set.
     pub fn limit(mut self, limit: usize) -> Self {
         self.limit = limit;
         self
     }
 
+
+    /// Set the event from which we should continue loading events.
+    ///
+    /// # Arguments
+    ///
+    /// * `event_id` - An event id of a previous event returned by this
+    /// method. If set events that are older than the event with the given
+    /// event ID will be returned.
     pub fn from_event<E: Into<String>>(mut self, event_id: E) -> Self {
         self.from_event = Some(event_id.into());
         self

--- a/src/config.rs
+++ b/src/config.rs
@@ -249,6 +249,7 @@ impl Default for Config {
 }
 
 #[derive(Debug, Clone)]
+#[allow(missing_docs)]
 pub enum LoadDirection {
     Backwards,
     Forwards,
@@ -293,7 +294,6 @@ impl LoadConfig {
         self
     }
 
-
     /// Set the event from which we should continue loading events.
     ///
     /// # Arguments
@@ -306,6 +306,14 @@ impl LoadConfig {
         self
     }
 
+    /// Set the direction that we are going to continue loading events from.
+    ///
+    /// This is only used if we are continuing loading events, that is if
+    /// `from_event()` is also set.
+    ///
+    /// # Arguments
+    ///
+    /// * `direction` - The direction that should be used.
     pub fn direction(mut self, direction: LoadDirection) -> Self {
         self.direction = direction;
         self

--- a/src/database.rs
+++ b/src/database.rs
@@ -27,7 +27,7 @@ use std::thread;
 use std::thread::JoinHandle;
 use zeroize::Zeroizing;
 
-use crate::config::{Config, LoadConfig, SearchConfig, LoadDirection};
+use crate::config::{Config, LoadConfig, LoadDirection, SearchConfig};
 use crate::error::{Error, Result};
 use crate::events::{
     CrawlerCheckpoint, Event, EventContext, EventId, HistoricEventsT, MxId, Profile,
@@ -929,9 +929,7 @@ impl Database {
                          (server_ts {} ?3)
                      ) ORDER BY server_ts {} LIMIT ?4
                      ",
-                    FILE_EVENT_TYPES,
-                    direction,
-                    sort
+                    FILE_EVENT_TYPES, direction, sort
                 ))?;
 
                 let room_id = Database::get_room_id(connection, &room_id)?;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use database::{Connection, Database, SearchResult, Searcher};
 
 pub use error::{Error, Result};
 
-pub use config::{Config, Language, SearchConfig, LoadConfig, LoadDirection};
+pub use config::{Config, Language, LoadConfig, LoadDirection, SearchConfig};
 pub use events::{CheckpointDirection, CrawlerCheckpoint, Event, EventType, Profile};
 
 pub use std::sync::mpsc::Receiver;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use database::{Connection, Database, SearchResult, Searcher};
 
 pub use error::{Error, Result};
 
-pub use config::{Config, Language, LoadConfig, SearchConfig};
+pub use config::{Config, Language, SearchConfig, LoadConfig, LoadDirection};
 pub use events::{CheckpointDirection, CrawlerCheckpoint, Event, EventType, Profile};
 
 pub use std::sync::mpsc::Receiver;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -33,7 +33,7 @@ pub use database::{Connection, Database, SearchResult, Searcher};
 
 pub use error::{Error, Result};
 
-pub use config::{Config, Language, SearchConfig};
+pub use config::{Config, Language, LoadConfig, SearchConfig};
 pub use events::{CheckpointDirection, CrawlerCheckpoint, Event, EventType, Profile};
 
 pub use std::sync::mpsc::Receiver;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,8 +2,8 @@
 extern crate lazy_static;
 
 use seshat::{
-    CheckpointDirection, Config, CrawlerCheckpoint, Database, Event, EventType, Profile,
-    SearchConfig,
+    CheckpointDirection, Config, CrawlerCheckpoint, Database, Event, EventType, LoadConfig,
+    Profile, SearchConfig,
 };
 
 use std::path::Path;
@@ -320,8 +320,10 @@ fn load_file_events() {
 
     let connection = db.get_connection().unwrap();
 
+    let mut config = LoadConfig::new(&FILE_EVENT.room_id).limit(10);
+
     let result = connection
-        .load_file_events(&FILE_EVENT.room_id, 10, None)
+        .load_file_events(&config)
         .expect("Can't load file events");
     assert!(!result.is_empty());
     assert!(result.len() == 2);
@@ -329,15 +331,19 @@ fn load_file_events() {
     assert!(result.len() == 2);
     assert_eq!(result[1].0, FILE_EVENT.source);
 
+    config = config.limit(1);
+
     let result = connection
-        .load_file_events(&FILE_EVENT.room_id, 1, None)
+        .load_file_events(&config)
         .expect("Can't load file events");
     assert!(!result.is_empty());
     assert!(result.len() == 1);
     assert_eq!(result[0].0, IMAGE_EVENT.source);
 
+    config = config.from_event(&IMAGE_EVENT.event_id);
+
     let result = connection
-        .load_file_events(&FILE_EVENT.room_id, 1, Some(&IMAGE_EVENT.event_id))
+        .load_file_events(&config)
         .expect("Can't load file events with token");
 
     assert!(!result.is_empty());

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -3,7 +3,7 @@ extern crate lazy_static;
 
 use seshat::{
     CheckpointDirection, Config, CrawlerCheckpoint, Database, Event, EventType, LoadConfig,
-    Profile, SearchConfig, LoadDirection,
+    LoadDirection, Profile, SearchConfig,
 };
 
 use std::path::Path;

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -321,26 +321,26 @@ fn load_file_events() {
     let connection = db.get_connection().unwrap();
 
     let result = connection
-        .get_file_events(&FILE_EVENT.room_id, 10, None)
+        .load_file_events(&FILE_EVENT.room_id, 10, None)
         .expect("Can't load file events");
     assert!(!result.is_empty());
     assert!(result.len() == 2);
-    assert_eq!(result[0], IMAGE_EVENT.source);
+    assert_eq!(result[0].0, IMAGE_EVENT.source);
     assert!(result.len() == 2);
-    assert_eq!(result[1], FILE_EVENT.source);
+    assert_eq!(result[1].0, FILE_EVENT.source);
 
     let result = connection
-        .get_file_events(&FILE_EVENT.room_id, 1, None)
+        .load_file_events(&FILE_EVENT.room_id, 1, None)
         .expect("Can't load file events");
     assert!(!result.is_empty());
     assert!(result.len() == 1);
-    assert_eq!(result[0], IMAGE_EVENT.source);
+    assert_eq!(result[0].0, IMAGE_EVENT.source);
 
     let result = connection
-        .get_file_events(&FILE_EVENT.room_id, 1, Some(&IMAGE_EVENT.event_id))
+        .load_file_events(&FILE_EVENT.room_id, 1, Some(&IMAGE_EVENT.event_id))
         .expect("Can't load file events with token");
 
     assert!(!result.is_empty());
     assert!(result.len() == 1);
-    assert_eq!(result[0], FILE_EVENT.source);
+    assert_eq!(result[0].0, FILE_EVENT.source);
 }


### PR DESCRIPTION
This pull request implements some improvements to our file loading methods.

It adds the profile to the loaded event and adds the ability to continue loading events in both directions, going backwards in history was the only possibility until now.

The API has been also a bit simplified by using an object with a builder pattern for the arguments.

This is needed to implement https://github.com/matrix-org/matrix-react-sdk/pull/3858 and fix https://github.com/vector-im/riot-web/issues/4959 at least for Riot-desktop.