### PR TITLE
Couple of issues with the uncommitted events handling.

### DIFF
--- a/src/index.rs
+++ b/src/index.rs
@@ -410,3 +410,19 @@ fn japanese_tokenizer() {
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].1, event_id);
 }
+
+#[test]
+fn event_count() {
+    let tmpdir = TempDir::new().unwrap();
+    let config = Config::new().set_language(&Language::English);
+    let index = Index::new(&tmpdir, &config).unwrap();
+
+    let mut writer = index.get_writer().unwrap();
+
+    assert_eq!(writer.added_events, 0);
+    writer.add_event(&EVENT);
+    assert_eq!(writer.added_events, 1);
+
+    writer.force_commit().unwrap();
+    assert_eq!(writer.added_events, 0);
+}

--- a/src/index.rs
+++ b/src/index.rs
@@ -120,6 +120,7 @@ impl Writer {
         doc.add_text(self.room_id_field, &event.room_id);
 
         self.inner.add_document(doc);
+        self.added_events += 1;
     }
 }
 


### PR DESCRIPTION
These issues were uncovered during live testing with Riot.

Namely: 
* The wrong row id was returned when uncommitted events were added to the database.
* The number of uncommitted events could be larger than `SQLITE_MAX_VARIABLE_NUMBER` if a library user doesn't commit for a while.
* The `Index` didn't count the number of queued up events.