### PR TITLE
seshat: Add a method to get more stats out of the database.

### DIFF
--- a/seshat-node/lib/index.js
+++ b/seshat-node/lib/index.js
@@ -67,6 +67,16 @@ const seshat = require('../native');
  */
 
 /**
+ * @typedef databaseStats
+ * @type {Object}
+ * @property {number} size The number of bytes that the database is consuming on
+ * the disk.
+ * @property {number} eventCount The number events that are stored in the
+ * database.
+ * @property {number} roomCount The number of rooms the database knows about.
+ */
+
+/**
  * Seshat database.<br>
  *
  * A Seshat database can be used to store and index Matrix events. A full-text
@@ -304,6 +314,21 @@ class Seshat extends seshat.Seshat {
     async getSize() {
         return new Promise((resolve, reject) => {
             super.getSize((err, res) => {
+                if (err) reject(err);
+                else resolve(res);
+            });
+        });
+    }
+
+    /**
+     * Get statistical information of the database.
+     *
+     * @return {Promise<databaseStats>} A promise that will resolve to an object
+     * containing statistical information of the database.
+     */
+    async getStats() {
+        return new Promise((resolve, reject) => {
+            super.getStats((err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });

--- a/seshat-node/test/test.js
+++ b/seshat-node/test/test.js
@@ -441,6 +441,24 @@ describe('Database', function() {
         expect(events[1].event).toEqual(videoEvent);
     });
 
+    it('should allow us query the database for statistics', async function() {
+        const db = createDb();
+
+        let stats = await db.getStats(true);
+        expect(stats.eventCount).toBe(0);
+        expect(stats.roomCount).toBe(0);
+
+        db.addEvent(matrixEvent, matrixProfileOnlyDisplayName);
+        db.addEvent(fileEvent, matrixProfileOnlyDisplayName);
+        db.addEvent(imageEvent, matrixProfileOnlyDisplayName);
+        db.addEvent(videoEvent, matrixProfileOnlyDisplayName);
+
+        await db.commit(true);
+        stats = await db.getStats(true);
+        expect(stats.eventCount).toBe(4);
+        expect(stats.roomCount).toBe(1);
+        expect(stats.size).toBeGreaterThan(0);
+    });
 
     it('should throw an error when adding events with missing fields.', function() {
         delete matrixEvent.content;

--- a/src/events.rs
+++ b/src/events.rs
@@ -111,7 +111,7 @@ impl<T> Dummy<T> for Event {
             EventType::Message,
             "Hello world",
             Some("m.text"),
-            &format!("${}:{}", (0..10).fake::<u8>(), &domain),
+            &format!("${}:{}", (0..std::u64::MAX).fake::<u64>(), &domain),
             &format!(
                 "@{}:{}",
                 Username(EN).fake::<String>(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -29,7 +29,7 @@ mod events;
 mod index;
 mod japanese_tokenizer;
 
-pub use database::{Connection, Database, SearchResult, Searcher};
+pub use database::{Connection, Database, DatabaseStats, SearchResult, Searcher};
 
 pub use error::{Error, Result};
 


### PR DESCRIPTION
This PR implements the ability to get some additional stats out of the db, namely the number of events and rooms that are indexed.

This should allow us to show those stats in the UI as was requested in this comment https://github.com/matrix-org/matrix-react-sdk/pull/3672#issuecomment-560109494.