### PR TITLE
Add content value back

### DIFF
--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -22,7 +22,5 @@ neon-build = "=0.3.3"
 neon = "=0.3.3"
 fs_extra = "1.1.0"
 serde_json = "1.0.44"
-r2d2 = "0.8.8"
-r2d2_sqlite = "0.13.0"
 neon-serde = "=0.3.0"
 seshat = { path = "../../" }


### PR DESCRIPTION
This adds the content value back to the database, as mentioned it will be needed once we support re-creating the index (e.g. when we change the language settings).

This was removed in a0119351b163c6cabdc7257fa8ab829c4e2f8393.