### PR TITLE
seshat-node: Remove some lingering unused dependencies.

### DIFF
--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -22,7 +22,5 @@ neon-build = "=0.3.3"
 neon = "=0.3.3"
 fs_extra = "1.1.0"
 serde_json = "1.0.44"
-r2d2 = "0.8.8"
-r2d2_sqlite = "0.13.0"
 neon-serde = "=0.3.0"
 seshat = { path = "../../" }


### PR DESCRIPTION
The dependencies here were used because Seshat didn't wrap the
connection type in its own type. Now that it does they aren't needed
anymore.