### PR TITLE
Leaky reload mitigations

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -323,7 +323,7 @@ impl Index {
 
     pub fn get_writer(&self) -> Result<Writer, tv::Error> {
         Ok(Writer {
-            inner: self.index.writer(TANTIVY_WRITER_HEAP_SIZE)?,
+            inner: self.index.writer_with_num_threads(1, TANTIVY_WRITER_HEAP_SIZE)?,
             body_field: self.body_field,
             topic_field: self.topic_field,
             name_field: self.name_field,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -96,9 +96,10 @@ impl Writer {
     }
 
     fn commit_helper(&mut self, force: bool) -> Result<bool, tv::Error> {
-        if force
-            || self.added_events >= COMMIT_RATE
-            || self.commit_timestamp.elapsed() >= COMMIT_TIME
+        if self.added_events > 0
+            && (force
+                || self.added_events >= COMMIT_RATE
+                || self.commit_timestamp.elapsed() >= COMMIT_TIME)
         {
             self.inner.commit()?;
             self.added_events = 0;


### PR DESCRIPTION
Tantivy's `IndexReader::reload()` method creates data that only gets garbage collected once a `Searcher` is requested.

A reload is triggered in the default configuration, which we use, on every commit. This means unless users search the index memory usage will rise every time a commit is triggered.

Commits are rather computationally expensive so we should avoid triggering them unless necessary even if we didn't have this problem at hand.

While this doesn't fully remove the rising memory usage it does slow it down considerably since we're reloading only if data has changed.

The complete fix will hopefully land upstream in Tantivy. An issue has been opened upstream https://github.com/tantivy-search/tantivy/issues/777. The fix shouldn't really be controversial or hard.

The first patch removes commits and thus reloads if no documents were added to Tantivy, the second patch reduces the number of reloads if documents were added to Tantivy and thus a commit and reload are the right thing to do.