### PR TITLE
Updates for Tantivy 0.12.0.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ default = ["encryption"]
 encryption = ["rusqlite/sqlcipher"]
 
 [dependencies]
-tantivy = "0.11.3"
+tantivy = "0.12.0"
 tinysegmenter = "0.1.1"
 rusqlite = "0.21.0"
 fs_extra = "1.1.0"

--- a/src/error.rs
+++ b/src/error.rs
@@ -34,7 +34,7 @@ pub enum Error {
     DatabaseError(rusqlite::Error),
     #[fail(display = "Index error: {}", _0)]
     /// Error signaling that there was an error with the event indexer.
-    IndexError(tantivy::Error),
+    IndexError(tantivy::TantivyError),
     #[fail(display = "File system error: {}", _0)]
     /// Error signaling that there was an error while reading from the
     /// filesystem.
@@ -65,8 +65,8 @@ impl From<rusqlite::Error> for Error {
     }
 }
 
-impl From<tantivy::Error> for Error {
-    fn from(err: tantivy::Error) -> Self {
+impl From<tantivy::TantivyError> for Error {
+    fn from(err: tantivy::TantivyError) -> Self {
         Error::IndexError(err)
     }
 }

--- a/src/index/encrypted_dir.rs
+++ b/src/index/encrypted_dir.rs
@@ -622,7 +622,7 @@ impl Directory for EncryptedMmapDirectory {
         self.mmap_dir.atomic_write(path, &encrypted)
     }
 
-    fn watch(&self, watch_callback: WatchCallback) -> Result<WatchHandle, tantivy::Error> {
+    fn watch(&self, watch_callback: WatchCallback) -> Result<WatchHandle, tantivy::TantivyError> {
         self.mmap_dir.watch(watch_callback)
     }
 

--- a/src/index/japanese_tokenizer.rs
+++ b/src/index/japanese_tokenizer.rs
@@ -31,7 +31,7 @@
 // Either I'm doing something wrong or the compiler is not smart enough.
 
 use std::iter::Enumerate;
-use tantivy::tokenizer::{Token, TokenStream, Tokenizer};
+use tantivy::tokenizer::{Token, BoxTokenStream, TokenStream, Tokenizer};
 
 #[derive(Debug, Clone, Default)]
 pub struct TinySegmenterTokenizer;
@@ -42,10 +42,9 @@ impl TinySegmenterTokenizer {
     }
 }
 
-impl<'a> Tokenizer<'a> for TinySegmenterTokenizer {
-    type TokenStreamImpl = TinySegmenterTokenStream;
-    fn token_stream(&self, text: &'a str) -> Self::TokenStreamImpl {
-        TinySegmenterTokenStream::new(text)
+impl Tokenizer for TinySegmenterTokenizer {
+    fn token_stream<'a>(&self, text: &'a str) -> BoxTokenStream<'a> {
+        TinySegmenterTokenStream::new(text).into()
     }
 }
 

--- a/src/index/japanese_tokenizer.rs
+++ b/src/index/japanese_tokenizer.rs
@@ -31,7 +31,7 @@
 // Either I'm doing something wrong or the compiler is not smart enough.
 
 use std::iter::Enumerate;
-use tantivy::tokenizer::{Token, BoxTokenStream, TokenStream, Tokenizer};
+use tantivy::tokenizer::{BoxTokenStream, Token, TokenStream, Tokenizer};
 
 #[derive(Debug, Clone, Default)]
 pub struct TinySegmenterTokenizer;

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -91,11 +91,11 @@ pub(crate) struct Writer {
 }
 
 impl Writer {
-    pub fn commit(&mut self) -> Result<bool, tv::Error> {
+    pub fn commit(&mut self) -> Result<bool, tv::TantivyError> {
         self.commit_helper(false)
     }
 
-    fn commit_helper(&mut self, force: bool) -> Result<bool, tv::Error> {
+    fn commit_helper(&mut self, force: bool) -> Result<bool, tv::TantivyError> {
         if self.added_events > 0
             && (force
                 || self.added_events >= COMMIT_RATE
@@ -110,7 +110,7 @@ impl Writer {
         }
     }
 
-    pub fn force_commit(&mut self) -> Result<(), tv::Error> {
+    pub fn force_commit(&mut self) -> Result<(), tv::TantivyError> {
         self.commit_helper(true)?;
         Ok(())
     }
@@ -148,7 +148,7 @@ impl IndexSearcher {
         &self,
         term: &str,
         config: &SearchConfig,
-    ) -> Result<Vec<(f32, EventId)>, tv::Error> {
+    ) -> Result<Vec<(f32, EventId)>, tv::TantivyError> {
         let mut keys = Vec::new();
 
         let term = if let Some(room) = &config.room_id {
@@ -205,7 +205,7 @@ impl IndexSearcher {
 }
 
 impl Index {
-    pub fn new<P: AsRef<Path>>(path: P, config: &Config) -> Result<Index, tv::Error> {
+    pub fn new<P: AsRef<Path>>(path: P, config: &Config) -> Result<Index, tv::TantivyError> {
         let tokenizer_name = config.language.as_tokenizer_name();
 
         let text_field_options = Index::create_text_options(&tokenizer_name);
@@ -231,7 +231,7 @@ impl Index {
                     .register(&tokenizer_name, TinySegmenterTokenizer::new());
             }
             _ => {
-                let tokenizer = tv::tokenizer::SimpleTokenizer
+                let tokenizer = tv::tokenizer::TextAnalyzer::from(tv::tokenizer::SimpleTokenizer)
                     .filter(tv::tokenizer::RemoveLongFilter::limit(40))
                     .filter(tv::tokenizer::LowerCaser)
                     .filter(tv::tokenizer::Stemmer::new(config.language.as_tantivy()));
@@ -283,7 +283,7 @@ impl Index {
         path: P,
         old_passphrase: &str,
         new_passphrase: &str,
-    ) -> Result<(), tv::Error> {
+    ) -> Result<(), tv::TantivyError> {
         EncryptedMmapDirectory::change_passphrase(
             path,
             old_passphrase,
@@ -317,11 +317,11 @@ impl Index {
         }
     }
 
-    pub fn reload(&self) -> Result<(), tv::Error> {
+    pub fn reload(&self) -> Result<(), tv::TantivyError> {
         self.reader.reload()
     }
 
-    pub fn get_writer(&self) -> Result<Writer, tv::Error> {
+    pub fn get_writer(&self) -> Result<Writer, tv::TantivyError> {
         Ok(Writer {
             inner: self.index.writer_with_num_threads(1, TANTIVY_WRITER_HEAP_SIZE)?,
             body_field: self.body_field,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -21,7 +21,6 @@ mod japanese_tokenizer;
 use std::path::Path;
 use std::time::Duration;
 use tantivy as tv;
-use tantivy::tokenizer::Tokenizer;
 
 use crate::config::{Config, Language, SearchConfig};
 use crate::events::{Event, EventId, EventType};
@@ -323,7 +322,9 @@ impl Index {
 
     pub fn get_writer(&self) -> Result<Writer, tv::TantivyError> {
         Ok(Writer {
-            inner: self.index.writer_with_num_threads(1, TANTIVY_WRITER_HEAP_SIZE)?,
+            inner: self
+                .index
+                .writer_with_num_threads(1, TANTIVY_WRITER_HEAP_SIZE)?,
             body_field: self.body_field,
             topic_field: self.topic_field,
             name_field: self.name_field,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -2,8 +2,8 @@
 extern crate lazy_static;
 
 use seshat::{
-    CheckpointDirection, CrawlerCheckpoint, Database, Event, EventType, LoadConfig,
-    LoadDirection, Profile, SearchConfig,
+    CheckpointDirection, CrawlerCheckpoint, Database, Event, EventType, LoadConfig, LoadDirection,
+    Profile, SearchConfig,
 };
 
 #[cfg(feature = "encryption")]


### PR DESCRIPTION
This PR updates to Tantivy 0.12.0. This is needed because 0.12.0 includes the fix for the leaky behavior we got. It includes some breaking changes so a couple API adaptions were needed.