### PR TITLE
Serde derive

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ rand = "0.7.3"
 zeroize = "1.1.0"
 byteorder = "1.3.2"
 serde_json = "1.0.48"
+serde = { version = "1.0.104", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.1.0"

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -29,6 +29,7 @@ use crate::events::{CrawlerCheckpoint, Profile, SerializedEvent};
 use crate::Database;
 
 /// Statistical information about the database.
+#[derive(Serialize, Deserialize)]
 pub struct DatabaseStats {
     /// The number number of bytes the database is using on disk.
     pub size: u64,

--- a/src/database/searcher.rs
+++ b/src/database/searcher.rs
@@ -24,7 +24,7 @@ use crate::events::{MxId, Profile, SerializedEvent};
 use crate::index::IndexSearcher;
 use crate::Database;
 
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 /// A search result
 pub struct SearchResult {
     /// The score that the full text search assigned to this event.

--- a/src/events.rs
+++ b/src/events.rs
@@ -87,7 +87,7 @@ pub struct Event {
     /// The textual representation of a message, this part of the event will be
     /// indexed.
     pub content_value: String,
-    /// The type of the message if the event is of a m.room.text type.
+    /// The type of the message if the event is of a m.room.message type.
     pub msgtype: Option<String>,
     /// The unique identifier of this event.
     pub event_id: String,
@@ -186,7 +186,7 @@ impl Event {
 }
 
 /// A users profile information at the time an event was posted.
-#[derive(Debug, PartialEq, Default, Clone)]
+#[derive(Debug, PartialEq, Default, Clone, Serialize, Deserialize)]
 pub struct Profile {
     /// The users display name if one is set.
     pub displayname: Option<String>,
@@ -290,7 +290,7 @@ lazy_static! {
     ];
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 /// A checkpoint that remembers the current point in a room timeline when
 /// fetching the history of the room.
 pub struct CrawlerCheckpoint {
@@ -305,7 +305,7 @@ pub struct CrawlerCheckpoint {
     pub direction: CheckpointDirection,
 }
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub enum CheckpointDirection {
     Forwards,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,6 +54,9 @@
 #[macro_use]
 extern crate lazy_static;
 
+#[macro_use]
+extern crate serde;
+
 mod config;
 mod database;
 mod error;


### PR DESCRIPTION
In order to allow clients to derive things without duplicating full structs on their side, it's useful to have some things derive `Serialize` and `Deserialize`.

Also fixed a doc typo, hope that's ok, let me know if I should make a dedicated PR for that.