### PR TITLE
seshat: Enable WAL mode for the database.

### DIFF
--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -23,4 +23,4 @@ neon = "=0.3.3"
 fs_extra = "1.1.0"
 serde_json = "1.0.44"
 neon-serde = "=0.3.0"
-seshat = { version = "1.2.0" }
+seshat = { path = "../../", version = "1.2.0" }

--- a/src/database/recovery.rs
+++ b/src/database/recovery.rs
@@ -152,7 +152,7 @@ impl RecoveryDatabase {
             if let Some(file_name) = path.file_name() {
                 // Skip removing the events database, those will be needed for
                 // reindexing.
-                if file_name == EVENTS_DB_NAME {
+                if file_name.to_string_lossy().starts_with(EVENTS_DB_NAME) {
                     continue;
                 }
 


### PR DESCRIPTION
In the default journaling mode SQLite can end up throwing SQLITE_BUSY
errors in the case of parallel access.

We have a setup with a single writer thread and possibly multiple reader
threads. This is the perfect setup for WAL mode and as per docs[1] will
remove the chance of getting SQLITE_BUSY errors.

[1] https://www.sqlite.org/wal.html