### PR TITLE
Fixes to the reporting if events were already added to the db.

### DIFF
--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -23,4 +23,4 @@ neon = "=0.3.3"
 fs_extra = "1.1.0"
 serde_json = "1.0.44"
 neon-serde = "=0.3.0"
-seshat = { version = "1.3.0" }
+seshat = { path = "../../" }

--- a/seshat-node/native/src/utils.rs
+++ b/seshat-node/native/src/utils.rs
@@ -387,12 +387,12 @@ pub(crate) fn parse_event(
     Ok(Event {
         event_type,
         content_value,
+        msgtype,
         event_id,
         sender,
         server_ts: server_timestamp,
         room_id,
         source: event_source,
-        msgtype,
     })
 }
 

--- a/seshat-node/test/test.js
+++ b/seshat-node/test/test.js
@@ -269,7 +269,7 @@ describe('Database', function() {
         let ret = db.addHistoricEventsSync(events, checkPoint);
         expect(ret).toBeFalsy();
 
-        let ret = db.addHistoricEventsSync(events, checkPoint);
+        ret = db.addHistoricEventsSync(events, checkPoint);
         expect(ret).toBeTruthy();
     });
 

--- a/seshat-node/test/test.js
+++ b/seshat-node/test/test.js
@@ -239,6 +239,40 @@ describe('Database', function() {
         expect(ret2).toBeTruthy();
     });
 
+    it('shouldn\'t tell us that all events are added if none were given', async function() {
+        const db = createDb();
+        let ret = db.addHistoricEventsSync([], checkPoint);
+        expect(ret).toBeFalsy();
+    });
+
+    it('should add messages to an encrypted db and correctly report if they are already added', async function() {
+        const tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seshat-'));
+        const db = new Seshat(tempDir, {passphrase: "wordpass"});
+        expect(await db.isEmpty()).toBeTruthy();
+
+        const messageEvent = {
+            type: 'm.room.message',
+            event_id: '$1578495730213684WVvXE:matrix.org',
+            room_id: '!BJWoSxvSUNxDYIozgz:matrix.org',
+            sender: '@test:matrix.org',
+            content: {
+                body: 'Test message',
+                msgtype: 'm.text',
+            },
+            origin_server_ts: 1578495730471,
+        };
+
+        const events = [
+          {event: messageEvent, profile: matrixProfileOnlyDisplayName}
+        ]
+
+        let ret = db.addHistoricEventsSync(events, checkPoint);
+        expect(ret).toBeFalsy();
+
+        let ret = db.addHistoricEventsSync(events, checkPoint);
+        expect(ret).toBeTruthy();
+    });
+
     it('should allow messages from the backlog to be added using a promise', async function() {
         const db = createDb();
         let ret = await db.addHistoricEvents(exampleEvents, checkPoint)

--- a/src/database/static_methods.rs
+++ b/src/database/static_methods.rs
@@ -600,7 +600,7 @@ impl Database {
             None => {
                 let mut stmt = connection.prepare(
                     "SELECT source FROM events
-                     WHERE type == 'm.room.message' 
+                     WHERE type == 'm.room.message'
                      ORDER BY server_ts DESC LIMIT ?1
                      ",
                 )?;

--- a/src/database/writer.rs
+++ b/src/database/writer.rs
@@ -84,6 +84,7 @@ impl Writer {
         mut events: Vec<(Event, Profile)>,
         force_commit: bool,
     ) -> Result<bool> {
+        let empty_events = events.is_empty();
         let (ret, committed) = Database::write_events(
             &mut self.connection,
             &mut self.inner,
@@ -96,7 +97,11 @@ impl Writer {
             self.mark_events_as_deleted()?;
         }
 
-        Ok(ret)
+        if empty_events {
+            Ok(false)
+        } else {
+            Ok(ret)
+        }
     }
 
     pub fn load_unprocessed_events(&mut self) -> Result<()> {


### PR DESCRIPTION
This PR adds a couple of fixes to the reporting if events that are added using the `addHistoricEvents()` method were already added.

The database would report that events are added if an empty list was given, while it's true that an empty list is always in the db, we don't want our crawlers to abort further crawling using this checkpoint so report `false` in that special case.

We're also changing a bit the way how we check if an event is in the database, switching to `SELECT COUNT(*)` instead of selecting the row id of the event. This way we can more easily differentiate if an error was raised because no row id was found vs if a database error was thrown.