### PR TITLE
Switch from failure to thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,6 @@ rusqlite = "0.22.0"
 fs_extra = "1.1.0"
 r2d2_sqlite = "0.15.0"
 r2d2 = "0.8.8"
-failure = "0.1.7"
 aes-ctr = "0.3.0"
 crypto-mac = "0.7.0"
 hmac = "0.7.1"
@@ -31,6 +30,7 @@ zeroize = "1.1.0"
 byteorder = "1.3.4"
 serde_json = "1.0.51"
 serde = { version = "1.0.106", default-features = false, features = ["derive"] }
+thiserror = "1.0.15"
 
 [dev-dependencies]
 tempfile = "3.1.0"


### PR DESCRIPTION
[`thiserror`](https://github.com/dtolnay/thiserror) exposes std errors to consumers of seshat, which makes error handling much easier compared to the custom trait exposed by `failure`.

`thiserror` seems to get more traction for various reasons, e.g. some discussion why cranelift switched from `failure` to `thiserror` can be found [here](https://github.com/bytecodealliance/cranelift/pull/1188#issuecomment-547956508).