### PR TITLE
seshat: More serde deriving

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -19,7 +19,8 @@ use crate::events::{EventType, RoomId};
 
 const DEFAULT_LOAD_LIMIT: usize = 20;
 
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(default)]
 /// Search configuration
 /// A search configuration allows users to limit the search to a specific room
 /// or limit the search to specific event types.
@@ -252,10 +253,12 @@ impl Default for Config {
     }
 }
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub enum LoadDirection {
+    #[serde(rename = "b", alias = "backwards", alias = "backward")]
     Backwards,
+    #[serde(rename = "f", alias = "forwards", alias = "forward")]
     Forwards,
 }
 
@@ -264,7 +267,7 @@ pub enum LoadDirection {
 /// A load configuration allows users to limit the number of events that will be
 /// loaded or to continue loading events from a specific point in the room
 /// history.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct LoadConfig {
     pub(crate) room_id: String,
     pub(crate) limit: usize,

--- a/src/database/connection.rs
+++ b/src/database/connection.rs
@@ -30,6 +30,7 @@ use crate::Database;
 
 /// Statistical information about the database.
 #[derive(Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct DatabaseStats {
     /// The number number of bytes the database is using on disk.
     pub size: u64,

--- a/src/events.rs
+++ b/src/events.rs
@@ -28,16 +28,19 @@ use fake::locales::*;
 use fake::{Dummy, Fake};
 
 /// Matrix event types.
-#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Clone, Serialize, Deserialize)]
 pub enum EventType {
     /// Matrix room messages, corresponds to the m.room.message type, has a body
     /// inside of the content.
+    #[serde(alias = "m.room.message", alias = "content.body")]
     Message,
     /// Matrix room messages, corresponds to the m.room.name type, has a name
     /// inside of the content.
+    #[serde(alias = "m.room.name", alias = "content.name")]
     Name,
     /// Matrix room messages, corresponds to the m.room.topic type, has a topic
     /// inside of the content.
+    #[serde(alias = "m.room.topic", alias = "content.topic")]
     Topic,
 }
 
@@ -80,7 +83,7 @@ impl FromSql for EventType {
 }
 
 /// Matrix event that can be added to the database.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 pub struct Event {
     /// The type of the event.
     pub event_type: EventType,
@@ -291,6 +294,7 @@ lazy_static! {
 }
 
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 /// A checkpoint that remembers the current point in a room timeline when
 /// fetching the history of the room.
 pub struct CrawlerCheckpoint {
@@ -300,6 +304,8 @@ pub struct CrawlerCheckpoint {
     /// the room and fetch more messages from the room history.
     pub token: String,
     /// Is this a checkpoint for a complete crawl of the message history.
+    // bool defaults to `false`
+    #[serde(default)]
     pub full_crawl: bool,
     /// The direction which should be used to crawl the room timeline.
     pub direction: CheckpointDirection,
@@ -308,7 +314,9 @@ pub struct CrawlerCheckpoint {
 #[derive(Debug, PartialEq, Clone, Serialize, Deserialize)]
 #[allow(missing_docs)]
 pub enum CheckpointDirection {
+    #[serde(rename = "f", alias = "forwards", alias = "forward")]
     Forwards,
+    #[serde(rename = "b", alias = "backwards", alias = "backward")]
     Backwards,
 }
 


### PR DESCRIPTION
As seshat consumer that deals with JSON the additional serde deriving helps with preventing duplicated code and makes working with strongly typed data structures easier.

Might also make sense to check where its now possible to use the derived things in seshat-node.