### PR TITLE
Paginated search

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,8 @@ rusqlite = "0.23.1"
 fs_extra = "1.1.0"
 r2d2_sqlite = "0.16.0"
 r2d2 = "0.8.8"
+lru-cache = "0.1.2"
+uuid = { version = "0.8.1", features = ["v4"] }
 
 aes-ctr = { version = "0.3.0", optional = true }
 crypto-mac = { version = "0.7.0", optional = true }

--- a/seshat-node/lib/index.js
+++ b/seshat-node/lib/index.js
@@ -18,10 +18,31 @@ const seshat = require('../native');
 /**
  * @typedef searchResult
  * @type {Object}
- * @property {number} rank The rank of the search result.
- * @property {Object} matrixEvent The full event of the search result.
+ * @property {string} next_batch A token that can be used to grab more results
+ * in the next search call.
+ * @property {number} count The total number of results that were found.
+ * @property {Array.<singleResult>} results The list of results that was found.
  */
 
+/**
+ * @typedef singleResult
+ * @type {Object}
+ * @property {number} rank The rank of the search result.
+ * @property {matrixEvent} result The full event of the search result.
+ * @property {searchContext} context The context of the result, containing
+ * events before and after the result.
+ */
+
+/**
+ * @typedef searchContext
+ * @type {Object}
+ * @property {Array.<matrixEvent>} events_before Events that happened before the
+ * search result.
+ * @property {Array.<matrixEvent>} events_after Events that happened after the
+ * search result.
+ * @property {{user_id: matrixProfile}} profile_info The historic profile
+ * information of the users that sent the events returned.
+ */
 
 /**
  * @typedef matrixEvent
@@ -169,8 +190,7 @@ class Seshat extends seshat.Seshat {
      * @param  {matrixProfile} profile The user profile of the sender at the
      * time the event was sent.
      *
-     * @return {Array.<searchResult>} The array of events that matched the
-     * search term.
+     * @return {Void}
      */
     addEvent(matrixEvent, profile = {}) {
         return super.addEvent(matrixEvent, profile);
@@ -261,8 +281,10 @@ class Seshat extends seshat.Seshat {
      * followed the event that matched the search term.
      * @param  {boolean} args.order_by_recency Should the search results be
      * ordered by event recency.
+     * @param  {string} args.next_batch Should the search results be
+     * ordered by event recency.
      *
-     * @return {Promise<Array.<searchResult>>} The array of events that matched
+     * @return {Promise<searchResult>} The array of events that matched
      * the search term.
      */
     async search(args) {
@@ -287,7 +309,7 @@ class Seshat extends seshat.Seshat {
      * @param  {boolean} order_by_recency Should the search results be ordered
      * by event recency.
      *
-     * @return {Array.<searchResult>} The array of events that matched the
+     * @return {searchResult} The array of events that matched the
      * search term.
      */
     searchSync(term, limit = 10, before_limit = 0, after_limit = 0,

--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -23,4 +23,5 @@ neon = "0.4.0"
 fs_extra = "1.1.0"
 serde_json = "1.0.53"
 neon-serde = "0.4.0"
-seshat = "1.3.3"
+uuid = { version = "0.8.1" }
+seshat = { version = "1.3.3", path = "../../" }

--- a/seshat-node/native/src/lib.rs
+++ b/seshat-node/native/src/lib.rs
@@ -419,11 +419,11 @@ declare_types! {
                 Err(e) => return cx.throw_type_error(e.to_string()),
             };
 
-            let count = ret.0;
+            let count = ret.1;
             let results = JsArray::new(&mut cx, count as u32);
             let count = JsNumber::new(&mut cx, count as f64);
 
-            for (i, element) in ret.1.drain(..).enumerate() {
+            for (i, element) in ret.2.drain(..).enumerate() {
                 let object = search_result_to_js(&mut cx, element)?;
                 results.set(&mut cx, i as u32, object)?;
             }
@@ -434,6 +434,11 @@ declare_types! {
             search_result.set(&mut cx, "count", count)?;
             search_result.set(&mut cx, "results", results)?;
             search_result.set(&mut cx, "highlights", highlights)?;
+
+            if let Some(next_batch) = ret.0 {
+                let next_batch = JsString::new(&mut cx, next_batch.to_hyphenated().to_string());
+                search_result.set(&mut cx, "next_batch", next_batch)?;
+            }
 
             Ok(search_result.upcast())
         }

--- a/seshat-node/native/src/utils.rs
+++ b/seshat-node/native/src/utils.rs
@@ -14,6 +14,7 @@
 
 use crate::Seshat;
 use neon::prelude::*;
+use uuid::Uuid;
 use neon_serde;
 use serde_json;
 use seshat::{
@@ -94,6 +95,18 @@ pub(crate) fn parse_search_object(
     if let Ok(r) = argument.get(&mut *cx, "room_id") {
         if let Ok(r) = r.downcast::<JsString>() {
             config.for_room(&r.value());
+        }
+    }
+
+    if let Ok(t) = argument.get(&mut *cx, "next_batch") {
+        if let Ok(t) = t.downcast::<JsString>() {
+            let token = if let Ok(t) = Uuid::parse_str(&t.value()) {
+                t
+            } else {
+                return cx.throw_type_error(format!("Invalid next_batch token {}", t.value()));
+            };
+
+            config.next_batch(token);
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -114,7 +114,8 @@ impl SearchConfig {
         self
     }
 
-    /// Set the next batch.
+    /// The point to return events from. If given, this should be a next_batch
+    /// result from a previous search.
     pub fn next_batch(&mut self, token: Uuid) -> &mut Self {
         self.next_batch = Some(token);
         self

--- a/src/config.rs
+++ b/src/config.rs
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+use uuid::Uuid;
 #[cfg(feature = "encryption")]
 use zeroize::Zeroizing;
 
@@ -32,6 +33,7 @@ pub struct SearchConfig {
     pub(crate) order_by_recency: bool,
     pub(crate) room_id: Option<RoomId>,
     pub(crate) keys: Vec<EventType>,
+    pub(crate) next_batch: Option<Uuid>,
 }
 
 impl SearchConfig {
@@ -111,6 +113,12 @@ impl SearchConfig {
 
         self
     }
+
+    /// Set the next batch.
+    pub fn next_batch(&mut self, token: Uuid) -> &mut Self {
+        self.next_batch = Some(token);
+        self
+    }
 }
 
 impl Default for SearchConfig {
@@ -122,6 +130,7 @@ impl Default for SearchConfig {
             order_by_recency: false,
             room_id: None,
             keys: Vec::new(),
+            next_batch: None,
         }
     }
 }

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -24,6 +24,7 @@ use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::ToSql;
 #[cfg(feature = "encryption")]
 use rusqlite::NO_PARAMS;
+use uuid::Uuid;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, Sender};
@@ -405,7 +406,7 @@ impl Database {
     /// # Arguments
     ///
     /// * `term` - The search term that should be used to search the index.
-    pub fn search(&self, term: &str, config: &SearchConfig) -> Result<(usize, Vec<SearchResult>)> {
+    pub fn search(&self, term: &str, config: &SearchConfig) -> Result<(Option<Uuid>, usize, Vec<SearchResult>)> {
         let searcher = self.get_searcher();
         searcher.search(term, config)
     }
@@ -866,7 +867,7 @@ fn resume_committing() {
     assert!(db
         .search("test", &SearchConfig::new())
         .unwrap()
-        .1
+        .2
         .is_empty());
 
     // Let us drop the DB to check if we're loading the uncommitted events
@@ -905,7 +906,7 @@ fn resume_committing() {
             .is_empty()
     );
 
-    let result = db.search("test", &SearchConfig::new()).unwrap().1;
+    let result = db.search("test", &SearchConfig::new()).unwrap().2;
 
     // The search is now successful.
     assert!(!result.is_empty());
@@ -1016,7 +1017,7 @@ fn database_upgrade_v1_2() {
     let (version, _) = Database::get_version(&mut connection).unwrap();
     assert_eq!(version, DATABASE_VERSION);
 
-    let result = db.search("Hello", &SearchConfig::new()).unwrap().1;
+    let result = db.search("Hello", &SearchConfig::new()).unwrap().2;
     assert!(!result.is_empty())
 }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -53,7 +53,7 @@ use crate::events::CheckpointDirection;
 #[cfg(test)]
 use crate::{EVENT, TOPIC_EVENT};
 
-const DATABASE_VERSION: i64 = 3;
+const DATABASE_VERSION: i64 = 4;
 const EVENTS_DB_NAME: &str = "events.db";
 
 pub(crate) enum ThreadMessage {

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -21,9 +21,9 @@ mod writer;
 use fs_extra::dir;
 use r2d2::PooledConnection;
 use r2d2_sqlite::SqliteConnectionManager;
+use rusqlite::ToSql;
 #[cfg(feature = "encryption")]
 use rusqlite::NO_PARAMS;
-use rusqlite::ToSql;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, Sender};

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -24,13 +24,13 @@ use r2d2_sqlite::SqliteConnectionManager;
 use rusqlite::ToSql;
 #[cfg(feature = "encryption")]
 use rusqlite::NO_PARAMS;
-use uuid::Uuid;
 use std::fs;
 use std::path::{Path, PathBuf};
 use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
+use uuid::Uuid;
 
 use crate::config::{Config, SearchConfig};
 pub use crate::database::connection::{Connection, DatabaseStats};
@@ -406,7 +406,11 @@ impl Database {
     /// # Arguments
     ///
     /// * `term` - The search term that should be used to search the index.
-    pub fn search(&self, term: &str, config: &SearchConfig) -> Result<(Option<Uuid>, usize, Vec<SearchResult>)> {
+    pub fn search(
+        &self,
+        term: &str,
+        config: &SearchConfig,
+    ) -> Result<(Option<Uuid>, usize, Vec<SearchResult>)> {
         let searcher = self.get_searcher();
         searcher.search(term, config)
     }

--- a/src/database/recovery.rs
+++ b/src/database/recovery.rs
@@ -428,7 +428,7 @@ pub(crate) mod test {
         assert_eq!(version, DATABASE_VERSION);
         assert_eq!(reindex_needed, false);
 
-        let result = db.search("Hello", &SearchConfig::new()).unwrap().1;
+        let result = db.search("Hello", &SearchConfig::new()).unwrap().2;
         assert!(!result.is_empty())
     }
 }

--- a/src/database/searcher.rs
+++ b/src/database/searcher.rs
@@ -17,6 +17,7 @@ use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
 
+use uuid::Uuid;
 use r2d2::PooledConnection;
 use r2d2_sqlite::SqliteConnectionManager;
 
@@ -60,11 +61,11 @@ impl Searcher {
     ///
     /// Returns a tuple of the count of matching documents and a list of
     /// `SearchResult`.
-    pub fn search(&self, term: &str, config: &SearchConfig) -> Result<(usize, Vec<SearchResult>)> {
+    pub fn search(&self, term: &str, config: &SearchConfig) -> Result<(Option<Uuid>, usize, Vec<SearchResult>)> {
         let search_result = self.inner.search(term, config)?;
 
         if search_result.results.is_empty() {
-            return Ok((0, vec![]));
+            return Ok((search_result.next_batch, 0, vec![]));
         }
 
         let mut retry = 0;
@@ -98,6 +99,6 @@ impl Searcher {
             }
         };
 
-        Ok((search_result.count, events))
+        Ok((search_result.next_batch, search_result.count, events))
     }
 }

--- a/src/database/searcher.rs
+++ b/src/database/searcher.rs
@@ -17,9 +17,9 @@ use std::sync::{Arc, Mutex};
 use std::thread::sleep;
 use std::time::Duration;
 
-use uuid::Uuid;
 use r2d2::PooledConnection;
 use r2d2_sqlite::SqliteConnectionManager;
+use uuid::Uuid;
 
 use crate::config::SearchConfig;
 use crate::error::Result;
@@ -61,7 +61,11 @@ impl Searcher {
     ///
     /// Returns a tuple of the count of matching documents and a list of
     /// `SearchResult`.
-    pub fn search(&self, term: &str, config: &SearchConfig) -> Result<(Option<Uuid>, usize, Vec<SearchResult>)> {
+    pub fn search(
+        &self,
+        term: &str,
+        config: &SearchConfig,
+    ) -> Result<(Option<Uuid>, usize, Vec<SearchResult>)> {
         let search_result = self.inner.search(term, config)?;
 
         if search_result.results.is_empty() {

--- a/src/database/searcher.rs
+++ b/src/database/searcher.rs
@@ -61,9 +61,9 @@ impl Searcher {
     /// Returns a tuple of the count of matching documents and a list of
     /// `SearchResult`.
     pub fn search(&self, term: &str, config: &SearchConfig) -> Result<(usize, Vec<SearchResult>)> {
-        let (count, search_result) = self.inner.search(term, config)?;
+        let search_result = self.inner.search(term, config)?;
 
-        if search_result.is_empty() {
+        if search_result.results.is_empty() {
             return Ok((0, vec![]));
         }
 
@@ -72,7 +72,7 @@ impl Searcher {
         let events = loop {
             match Database::load_events(
                 &*self.database.lock().unwrap(),
-                &search_result,
+                &search_result.results,
                 config.before_limit,
                 config.after_limit,
                 config.order_by_recency,
@@ -98,6 +98,6 @@ impl Searcher {
             }
         };
 
-        Ok((count, events))
+        Ok((search_result.count, events))
     }
 }

--- a/src/database/static_methods.rs
+++ b/src/database/static_methods.rs
@@ -255,6 +255,17 @@ impl Database {
             version = 3;
         }
 
+        if version == 3 {
+            let transaction = connection.transaction()?;
+
+            transaction.execute("UPDATE reindex_needed SET reindex_needed = ?1", &[true])?;
+            transaction.execute("UPDATE version SET version = '4'", NO_PARAMS)?;
+            transaction.commit()?;
+
+            reindex_needed = true;
+            version = 4;
+        }
+
         Ok((version, reindex_needed))
     }
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -294,8 +294,8 @@ impl IndexSearcher {
                 Ok(((count, docs), event_ids))
             } else {
                 self.search_helper(
-                    limit + SEARCH_LIMIT_INCREMENT,
                     og_limit,
+                    limit + SEARCH_LIMIT_INCREMENT,
                     order_by_recency,
                     &previous_results,
                     &query,

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -287,6 +287,10 @@ impl IndexSearcher {
 
             event_ids.push(event_id.clone());
             docs.push((score, event_id));
+
+            if docs.len() >= og_limit {
+                break;
+            }
         }
 
         if docs.len() < og_limit {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -82,18 +82,24 @@ pub(crate) struct Index {
     sender_field: tv::schema::Field,
     date_field: tv::schema::Field,
     room_id_field: tv::schema::Field,
+    search_cache: Arc<RwLock<LruCache<String, String>>>,
+}
+
+struct Search {
+    event_ids: Vec<String>,
+    search_term: String,
 }
 
 pub(crate) struct Writer {
-    pub(crate) inner: tv::IndexWriter,
-    pub(crate) body_field: tv::schema::Field,
-    pub(crate) topic_field: tv::schema::Field,
-    pub(crate) name_field: tv::schema::Field,
-    pub(crate) event_id_field: tv::schema::Field,
-    pub(crate) sender_field: tv::schema::Field,
-    pub(crate) date_field: tv::schema::Field,
-    pub(crate) added_events: usize,
-    pub(crate) commit_timestamp: std::time::Instant,
+    inner: tv::IndexWriter,
+    body_field: tv::schema::Field,
+    topic_field: tv::schema::Field,
+    name_field: tv::schema::Field,
+    event_id_field: tv::schema::Field,
+    sender_field: tv::schema::Field,
+    date_field: tv::schema::Field,
+    added_events: usize,
+    commit_timestamp: std::time::Instant,
     room_id_field: tv::schema::Field,
 }
 
@@ -163,18 +169,18 @@ impl Writer {
 }
 
 pub(crate) struct IndexSearcher {
-    pub(crate) inner: tv::LeasedItem<tv::Searcher>,
-    pub(crate) schema: tv::schema::Schema,
-    pub(crate) tokenizer: tv::tokenizer::TokenizerManager,
-    pub(crate) body_field: tv::schema::Field,
-    pub(crate) topic_field: tv::schema::Field,
-    pub(crate) name_field: tv::schema::Field,
-    pub(crate) room_id_field: tv::schema::Field,
+    inner: tv::LeasedItem<tv::Searcher>,
+    schema: tv::schema::Schema,
+    tokenizer: tv::tokenizer::TokenizerManager,
+    body_field: tv::schema::Field,
+    topic_field: tv::schema::Field,
+    name_field: tv::schema::Field,
+    room_id_field: tv::schema::Field,
     #[used]
-    pub(crate) sender_field: tv::schema::Field,
+    sender_field: tv::schema::Field,
     #[used]
-    pub(crate) date_field: tv::schema::Field,
-    pub(crate) event_id_field: tv::schema::Field,
+    date_field: tv::schema::Field,
+    event_id_field: tv::schema::Field,
 }
 
 impl IndexSearcher {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -184,7 +184,7 @@ fn save_and_search() {
     db.force_commit().unwrap();
     db.reload().unwrap();
 
-    let result = db.search("Test", &Default::default()).unwrap().1;
+    let result = db.search("Test", &Default::default()).unwrap().2;
     assert!(!result.is_empty());
     assert_eq!(result[0].event_source, EVENT.source);
 }
@@ -202,7 +202,7 @@ fn duplicate_events() {
     db.reload().unwrap();
 
     let searcher = db.get_searcher();
-    let result = searcher.search("Test", &Default::default()).unwrap().1;
+    let result = searcher.search("Test", &Default::default()).unwrap().2;
     assert_eq!(result.len(), 1);
 }
 
@@ -275,7 +275,7 @@ fn add_differing_events() {
     db.reload().unwrap();
 
     let searcher = db.get_searcher();
-    let result = searcher.search("Test", &SearchConfig::new()).unwrap().1;
+    let result = searcher.search("Test", &SearchConfig::new()).unwrap().2;
     assert_eq!(result.len(), 2);
 }
 
@@ -293,7 +293,7 @@ fn search_with_specific_key() {
     let result = searcher
         .search("Test", &SearchConfig::new().with_key(EventType::Topic))
         .unwrap()
-        .1;
+        .2;
     assert!(result.is_empty());
 
     db.add_event(TOPIC_EVENT.clone(), profile);
@@ -304,7 +304,7 @@ fn search_with_specific_key() {
     let result = searcher
         .search("Test", &SearchConfig::new().with_key(EventType::Topic))
         .unwrap()
-        .1;
+        .2;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].event_source, TOPIC_EVENT.source)
 }
@@ -334,7 +334,7 @@ fn encrypted_save_and_search() {
     db.force_commit().unwrap();
     db.reload().unwrap();
 
-    let result = db.search("Test", &Default::default()).unwrap().1;
+    let result = db.search("Test", &Default::default()).unwrap().2;
     assert!(!result.is_empty());
     assert_eq!(result[0].event_source, EVENT.source);
 }
@@ -438,7 +438,7 @@ fn delete_events() {
     db.reload().unwrap();
 
     let searcher = db.get_searcher();
-    let result = searcher.search("Test", &SearchConfig::new()).unwrap().1;
+    let result = searcher.search("Test", &SearchConfig::new()).unwrap().2;
     assert_eq!(result.len(), 2);
 
     let receiver = db.delete_event(&EVENT.event_id);
@@ -447,7 +447,7 @@ fn delete_events() {
     db.force_commit().unwrap();
     db.reload().unwrap();
 
-    let result = searcher.search("Test", &SearchConfig::new()).unwrap().1;
+    let result = searcher.search("Test", &SearchConfig::new()).unwrap().2;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].event_source, TOPIC_EVENT.source);
 }


### PR DESCRIPTION
This PR adds support to continue your search fetching at every subsequent search more and more search results until all search results are retrieved.

This sadly requires a re-index since we used a date field for our origin server timestamp and that one doesn't seem to support ordering.

The Riot side of things implementing this can be found [here](https://github.com/matrix-org/matrix-react-sdk/tree/poljar/seshat-search-pagination), but that's still missing a bit of cleanup.