### PR TITLE
seshat: Use a type as the return value of the search.

### DIFF
--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -11,10 +11,6 @@ edition = "2018"
 name = "seshat_node"
 crate-type = ["cdylib"]
 
-# We pin the neon versions since neon introduced a breaking change in a minor
-# version bump. While this is unlikely to occur again let us pin the versions
-# for a while.
-
 [build-dependencies]
 neon-build = "0.4.0"
 

--- a/seshat-node/native/src/lib.rs
+++ b/seshat-node/native/src/lib.rs
@@ -449,11 +449,11 @@ declare_types! {
                 Err(e) => return cx.throw_type_error(e.to_string()),
             };
 
-            let count = ret.1;
-            let results = JsArray::new(&mut cx, count as u32);
+            let count = ret.count;
+            let results = JsArray::new(&mut cx, ret.results.len() as u32);
             let count = JsNumber::new(&mut cx, count as f64);
 
-            for (i, element) in ret.2.drain(..).enumerate() {
+            for (i, element) in ret.results.drain(..).enumerate() {
                 let object = search_result_to_js(&mut cx, element)?;
                 results.set(&mut cx, i as u32, object)?;
             }
@@ -465,7 +465,7 @@ declare_types! {
             search_result.set(&mut cx, "results", results)?;
             search_result.set(&mut cx, "highlights", highlights)?;
 
-            if let Some(next_batch) = ret.0 {
+            if let Some(next_batch) = ret.next_batch {
                 let next_batch = JsString::new(&mut cx, next_batch.to_hyphenated().to_string());
                 search_result.set(&mut cx, "next_batch", next_batch)?;
             }

--- a/seshat-node/native/src/utils.rs
+++ b/seshat-node/native/src/utils.rs
@@ -14,13 +14,13 @@
 
 use crate::Seshat;
 use neon::prelude::*;
-use uuid::Uuid;
 use neon_serde;
 use serde_json;
 use seshat::{
     CheckpointDirection, Config, CrawlerCheckpoint, Event, EventType, Language, Profile, Receiver,
     SearchConfig, SearchResult,
 };
+use uuid::Uuid;
 
 pub(crate) fn parse_database_config(
     cx: &mut CallContext<JsUndefined>,

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -866,7 +866,7 @@ fn resume_committing() {
     assert!(db
         .search("test", &SearchConfig::new())
         .unwrap()
-        .2
+        .results
         .is_empty());
 
     // Let us drop the DB to check if we're loading the uncommitted events
@@ -905,7 +905,7 @@ fn resume_committing() {
             .is_empty()
     );
 
-    let result = db.search("test", &SearchConfig::new()).unwrap().2;
+    let result = db.search("test", &SearchConfig::new()).unwrap().results;
 
     // The search is now successful.
     assert!(!result.is_empty());
@@ -1016,7 +1016,7 @@ fn database_upgrade_v1_2() {
     let (version, _) = Database::get_version(&mut connection).unwrap();
     assert_eq!(version, DATABASE_VERSION);
 
-    let result = db.search("Hello", &SearchConfig::new()).unwrap().2;
+    let result = db.search("Hello", &SearchConfig::new()).unwrap().results;
     assert!(!result.is_empty())
 }
 

--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -30,12 +30,11 @@ use std::sync::mpsc::{channel, Receiver, Sender};
 use std::sync::{Arc, Mutex};
 use std::thread;
 use std::thread::JoinHandle;
-use uuid::Uuid;
 
 use crate::config::{Config, SearchConfig};
 pub use crate::database::connection::{Connection, DatabaseStats};
 pub use crate::database::recovery::{RecoveryDatabase, RecoveryInfo};
-pub use crate::database::searcher::{SearchResult, Searcher};
+pub use crate::database::searcher::{SearchBatch, SearchResult, Searcher};
 use crate::database::writer::Writer;
 use crate::error::{Error, Result};
 use crate::events::{CrawlerCheckpoint, Event, EventId, HistoricEventsT, Profile};
@@ -406,11 +405,7 @@ impl Database {
     /// # Arguments
     ///
     /// * `term` - The search term that should be used to search the index.
-    pub fn search(
-        &self,
-        term: &str,
-        config: &SearchConfig,
-    ) -> Result<(Option<Uuid>, usize, Vec<SearchResult>)> {
+    pub fn search(&self, term: &str, config: &SearchConfig) -> Result<SearchBatch> {
         let searcher = self.get_searcher();
         searcher.search(term, config)
     }

--- a/src/database/recovery.rs
+++ b/src/database/recovery.rs
@@ -428,7 +428,7 @@ pub(crate) mod test {
         assert_eq!(version, DATABASE_VERSION);
         assert_eq!(reindex_needed, false);
 
-        let result = db.search("Hello", &SearchConfig::new()).unwrap().2;
+        let result = db.search("Hello", &SearchConfig::new()).unwrap().results;
         assert!(!result.is_empty())
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,7 +64,8 @@ mod events;
 mod index;
 
 pub use database::{
-    Connection, Database, DatabaseStats, RecoveryDatabase, RecoveryInfo, SearchResult, Searcher,
+    Connection, Database, DatabaseStats, RecoveryDatabase, RecoveryInfo, SearchBatch, SearchResult,
+    Searcher,
 };
 
 pub use error::{Error, Result};

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -184,7 +184,7 @@ fn save_and_search() {
     db.force_commit().unwrap();
     db.reload().unwrap();
 
-    let result = db.search("Test", &Default::default()).unwrap().2;
+    let result = db.search("Test", &Default::default()).unwrap().results;
     assert!(!result.is_empty());
     assert_eq!(result[0].event_source, EVENT.source);
 }
@@ -202,7 +202,7 @@ fn duplicate_events() {
     db.reload().unwrap();
 
     let searcher = db.get_searcher();
-    let result = searcher.search("Test", &Default::default()).unwrap().2;
+    let result = searcher.search("Test", &Default::default()).unwrap().results;
     assert_eq!(result.len(), 1);
 }
 
@@ -275,7 +275,7 @@ fn add_differing_events() {
     db.reload().unwrap();
 
     let searcher = db.get_searcher();
-    let result = searcher.search("Test", &SearchConfig::new()).unwrap().2;
+    let result = searcher.search("Test", &SearchConfig::new()).unwrap().results;
     assert_eq!(result.len(), 2);
 }
 
@@ -293,7 +293,7 @@ fn search_with_specific_key() {
     let result = searcher
         .search("Test", &SearchConfig::new().with_key(EventType::Topic))
         .unwrap()
-        .2;
+        .results;
     assert!(result.is_empty());
 
     db.add_event(TOPIC_EVENT.clone(), profile);
@@ -304,7 +304,7 @@ fn search_with_specific_key() {
     let result = searcher
         .search("Test", &SearchConfig::new().with_key(EventType::Topic))
         .unwrap()
-        .2;
+        .results;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].event_source, TOPIC_EVENT.source)
 }
@@ -334,7 +334,7 @@ fn encrypted_save_and_search() {
     db.force_commit().unwrap();
     db.reload().unwrap();
 
-    let result = db.search("Test", &Default::default()).unwrap().2;
+    let result = db.search("Test", &Default::default()).unwrap().results;
     assert!(!result.is_empty());
     assert_eq!(result[0].event_source, EVENT.source);
 }
@@ -438,7 +438,7 @@ fn delete_events() {
     db.reload().unwrap();
 
     let searcher = db.get_searcher();
-    let result = searcher.search("Test", &SearchConfig::new()).unwrap().2;
+    let result = searcher.search("Test", &SearchConfig::new()).unwrap().results;
     assert_eq!(result.len(), 2);
 
     let receiver = db.delete_event(&EVENT.event_id);
@@ -447,7 +447,7 @@ fn delete_events() {
     db.force_commit().unwrap();
     db.reload().unwrap();
 
-    let result = searcher.search("Test", &SearchConfig::new()).unwrap().2;
+    let result = searcher.search("Test", &SearchConfig::new()).unwrap().results;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].event_source, TOPIC_EVENT.source);
 }


### PR DESCRIPTION
The addition of the `next_batch` token to the return value of the tuple return value of the search was a breaking change.

To avoid further breaking changes if our search return value gains additional fields return a type instead.