### PR TITLE
database: Improve the load times for the event context.

### DIFF
--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -23,4 +23,4 @@ fs_extra = "1.1.0"
 serde_json = "1.0.53"
 neon-serde = "=0.4.0"
 uuid = { version = "0.8.1" }
-seshat = { version = "2.1.0" }
+seshat = { version = "2.1.0", path = "../../" }

--- a/src/database/static_methods.rs
+++ b/src/database/static_methods.rs
@@ -364,7 +364,7 @@ impl Database {
         )?;
 
         conn.execute(
-            "CREATE INDEX IF NOT EXISTS room_event_id ON events (event_id)",
+            "CREATE INDEX IF NOT EXISTS event_id ON events (event_id)",
             NO_PARAMS,
         )?;
 


### PR DESCRIPTION
This patch mostly just adds a index to make loading the event context fast.

The mean time to load an event context before for my main DB was around 360.96ms, since Riot searches for 10 events at once we repeat that load 10 times and thus resulting in a total load time for the context of 3.62s.

This has now bean reduced to 20.89ms per context and a new total of 0.21s.

We still do two selects per event context which are timed here using the CLI tool separately, first the events that happened before our search result, then events that happened after.

    Run Time: real 0.000 user 0.000101 sys 0.000016
    Run Time: real 0.017 user 0.012570 sys 0.003698

It is unclear why finding the event after takes this much longer, this was in the 150ms ranges if the newly added index was only over the room_id and server_ts.

Another approach has been tried out which could reduce the number of SQL selects further but the numbers weren't looking promising enough to warrant a more disruptive change is the following SQL snippet:

```sql
WITH room_events AS (
    SELECT * from events WHERE room_id == ?1
)
SELECT event_id, context FROM (
    SELECT id,
        event_id,
        group_concat(event_id) OVER (
            ORDER BY server_ts ROWS BETWEEN 1 PRECEDING AND 1 FOLLOWING
        ) AS context
    FROM room_events
) as t
WHERE event_id IN (X);
```

This could load the events before and after in a single query, perhaps even the event context for all search results in a single query.

The run time for this query is as follows:

    Run Time: real 0.071 user 0.067942 sys 0.003090

I'm leaving this here so it doesn't get lost if needed.

This is an attempt to, if not fix, improve #72.