### PR TITLE
index: Don't fill out the whole 128 bit counter with randomness.

### DIFF
--- a/src/index/encrypted_stream.rs
+++ b/src/index/encrypted_stream.rs
@@ -61,7 +61,7 @@ impl<E: NewStreamCipher + SyncStreamCipher, M: Mac, W: Write> AesWriter<E, M, W>
     /// * `key`: The encryption key for the stream cipher.
     /// * `mac_key`: The authentication key for the MAC.
     /// * `iv_size`: The size of the initialization vector or nonce for the
-    /// streaam cipher.
+    /// stream cipher.
     pub fn new(
         mut writer: W,
         key: &[u8],
@@ -70,7 +70,7 @@ impl<E: NewStreamCipher + SyncStreamCipher, M: Mac, W: Write> AesWriter<E, M, W>
     ) -> Result<AesWriter<E, M, W>> {
         let mut iv = vec![0u8; iv_size];
         let mut rng = thread_rng();
-        rng.try_fill(&mut iv[..])
+        rng.try_fill(&mut iv[0..iv_size / 2])
             .map_err(|e| Error::new(ErrorKind::Other, format!("error generating iv: {:?}", e)))?;
 
         let mac = M::new_varkey(mac_key)


### PR DESCRIPTION
This patch changes the way our nonces/IVs are created, while it is quite unlikely that we would encounter an overflow of our counter, considering the files Tantivy creates, this makes sure that it can't happen.

The upper 64 bits are populated by randomness while the lower parts are left 0 initialized.

This aligns the set up to how the counter is created in the attachment encryption part of the Matrix spec as well.