### PR TITLE
Neon update continued

### DIFF
--- a/seshat-node/lib/index.js
+++ b/seshat-node/lib/index.js
@@ -13,36 +13,7 @@
 // limitations under the License.
 
 const { promisify } = require('util');
-const seshat_orig = require('../native');
-
-const seshat_recovery_new = seshat_orig.seshat_recovery_new;
-const seshat_recovery_info = seshat_orig.seshat_recovery_info;
-const seshat_new = seshat_orig.seshat_new;
-const seshat_addHistoricEventsSync = seshat_orig.seshat_addHistoricEventsSync;
-const seshat_searchSync = seshat_orig.seshat_searchSync;
-const seshat_commitSync = seshat_orig.seshat_commitSync;
-const seshat_addEvent = seshat_orig.seshat_addEvent;
-const seshat_reload = seshat_orig.seshat_reload;
-
-const seshat_recovery_reindex = promisify(seshat_orig.seshat_recovery_reindex);
-const seshat_recovery_getUserVersion = promisify(seshat_orig.seshat_recovery_getUserVersion);
-const seshat_recovery_shutdown = promisify(seshat_orig.seshat_recovery_shutdown);
-const seshat_addHistoricEvents = promisify(seshat_orig.seshat_addHistoricEvents);
-const seshat_loadCheckpoints = promisify(seshat_orig.seshat_loadCheckpoints);
-const seshat_deleteEvent = promisify(seshat_orig.seshat_deleteEvent);
-const seshat_commit = promisify(seshat_orig.seshat_commit);
-const seshat_getStats = promisify(seshat_orig.seshat_getStats);
-const seshat_getSize = promisify(seshat_orig.seshat_getSize);
-const seshat_isEmpty = promisify(seshat_orig.seshat_isEmpty);
-const seshat_isRoomIndexed = promisify(seshat_orig.seshat_isRoomIndexed);
-const seshat_getUserVersion = promisify(seshat_orig.seshat_getUserVersion);
-const seshat_setUserVersion = promisify(seshat_orig.seshat_setUserVersion);
-const seshat_search = promisify(seshat_orig.seshat_search);
-const seshat_delete = promisify(seshat_orig.seshat_delete);
-const seshat_changePassphrase = promisify(seshat_orig.seshat_changePassphrase);
-const seshat_shutdown = promisify(seshat_orig.seshat_shutdown);
-const seshat_loadFileEvents = promisify(seshat_orig.seshat_loadFileEvents);
-
+const seshatNative = require('../native');
 
 /**
  * @typedef searchResult
@@ -197,7 +168,7 @@ class Seshat {
     constructor(path, config = undefined) {
         config = config || {};
         try {
-            this.inner = seshat_new(path, config);
+            this.inner = seshatNative.createDb(path, config);
         } catch (e) {
             // The Rust side throws a RangeError, this is a bit silly so convert
             // it to a custom error.
@@ -222,7 +193,7 @@ class Seshat {
      * @return {Void}
      */
     addEvent(matrixEvent, profile = {}) {
-        return seshat_addEvent(this.inner, matrixEvent, profile);
+        return seshatNative.addEvent(this.inner, matrixEvent, profile);
     };
 
     /**
@@ -238,7 +209,8 @@ class Seshat {
      * from the index or if a commit later on will be needed.
      */
     async deleteEvent(eventId) {
-	return seshat_deleteEvent(this.inner, eventId);
+        const deleteEvent = promisify(seshatNative.deleteEvent);
+        return deleteEvent(this.inner, eventId);
     };
 
     /**
@@ -256,7 +228,8 @@ class Seshat {
      * a unique incrementing number that identifies the commit.
      */
     async commit(force = false) {
-	return seshat_commit(this.inner, force);
+        const commit = promisify(seshatNative.commit);
+        return commit(this.inner, force);
     }
 
     /**
@@ -273,7 +246,7 @@ class Seshat {
      * incrementing number that identifies the commit.
      */
     commitSync(wait = false, force = false) {
-        return seshat_commitSync(this.inner, wait, force);
+        return seshatNative.commitSync(this.inner, wait, force);
     }
 
     /**
@@ -282,7 +255,7 @@ class Seshat {
      * for unit testing purposes to force a reload before a search.
      */
     reload() {
-        seshat_reload(this.inner);
+        seshatNative.reload(this.inner);
     };
 
     /**
@@ -308,7 +281,8 @@ class Seshat {
      * the search term.
      */
     async search(args) {
-	return seshat_search(this.inner, args);
+        const search = promisify(seshatNative.search);
+        return search(this.inner, args);
     }
 
     /**
@@ -329,7 +303,7 @@ class Seshat {
      */
     searchSync(term, limit = 10, before_limit = 0, after_limit = 0,
         order_by_recency = false) {
-        return seshat_searchSync(this.inner, term, limit, before_limit, after_limit,
+        return seshatNative.searchSync(this.inner, term, limit, before_limit, after_limit,
             order_by_recency);
     }
 
@@ -345,7 +319,7 @@ class Seshat {
      * false otherwise.
      */
     addHistoricEventsSync(events, newCheckpoint = null, oldCheckPoint = null) {
-        return seshat_addHistoricEventsSync(this.inner, events, newCheckpoint,
+        return seshatNative.addHistoricEventsSync(this.inner, events, newCheckpoint,
             oldCheckPoint);
     }
 
@@ -361,7 +335,8 @@ class Seshat {
      * the events have already been added to the database, false otherwise.
      */
     async addHistoricEvents(events, newCheckpoint = null, oldCheckPoint = null) {
-	return seshat_addHistoricEvents(this.inner, events, newCheckpoint, oldCheckPoint);
+        const addHistoricEvents = promisify(seshatNative.addHistoricEvents);
+        return addHistoricEvents(this.inner, events, newCheckpoint, oldCheckPoint);
     }
 
     /**
@@ -395,7 +370,8 @@ class Seshat {
      * array of checkpoints when they are loaded from the database.
      */
     async loadCheckpoints() {
-	return seshat_loadCheckpoints(this.inner);
+        const loadCheckpoints = promisify(seshatNative.loadCheckpoints);
+        return loadCheckpoints(this.inner);
     }
 
     /**
@@ -406,7 +382,8 @@ class Seshat {
      * size in bytes.
      */
     async getSize() {
-        return seshat_getSize(this.inner);
+        const getSize = promisify(seshatNative.getSize);
+        return getSize(this.inner);
     }
 
     /**
@@ -416,7 +393,8 @@ class Seshat {
      * containing statistical information of the database.
      */
     async getStats() {
-        return seshat_getStats(this.inner);
+        const getStats = promisify(seshatNative.getStats);
+        return getStats(this.inner);
     }
 
     /**
@@ -426,7 +404,8 @@ class Seshat {
      * been deleted.
      */
     async delete() {
-        return seshat_delete(this.inner);
+        const deleteDb = promisify(seshatNative.deleteDb);
+        return deleteDb(this.inner);
     }
 
     /**
@@ -436,7 +415,8 @@ class Seshat {
      * been closed.
      */
     async shutdown() {
-	return seshat_shutdown(this.inner);
+        const shutdown = promisify(seshatNative.shutdown);
+        return shutdown(this.inner);
     }
 
     /**
@@ -451,7 +431,8 @@ class Seshat {
      * been changed.
      */
     async changePassphrase(newPassphrase) {
-	return seshat_changePassphrase(this.inner, newPassphrase);
+        const changePassphrase = promisify(seshatNative.changePassphrase);
+        return changePassphrase(this.inner, newPassphrase);
     }
 
     /**
@@ -462,7 +443,8 @@ class Seshat {
      * otherwise.
      */
     async isEmpty() {
-	return seshat_isEmpty(this.inner);
+        const isEmpty = promisify(seshatNative.isEmpty);
+        return isEmpty(this.inner);
     }
 
     /**
@@ -475,7 +457,8 @@ class Seshat {
      * database contains events for the given room, false otherwise.
      */
     async isRoomIndexed(roomId) {
-	return seshat_isRoomIndexed(this.inner, roomId);
+        const isRoomIndexed = promisify(seshatNative.isRoomIndexed);
+        return isRoomIndexed(this.inner, roomId);
     }
 
     /**
@@ -485,7 +468,8 @@ class Seshat {
      * represents the user version of the database.
      */
     async getUserVersion() {
-	return seshat_getUserVersion(this.inner);
+        const getUserVersion = promisify(seshatNative.getUserVersion);
+        return getUserVersion(this.inner);
     }
 
     /**
@@ -498,7 +482,8 @@ class Seshat {
      * has been stored in the database.
      */
     async setUserVersion(version) {
-	return seshat_setUserVersion(this.inner, version);
+        const setUserVersion = promisify(seshatNative.setUserVersion);
+        return setUserVersion(this.inner, version);
     }
 
     /**
@@ -519,7 +504,8 @@ class Seshat {
      * of Matrix events that contain mxc URLs.
      */
     async loadFileEvents(args) {
-	return seshat_loadFileEvents(this.inner, args);
+        const loadFileEvents = promisify(seshatNative.loadFileEvents);
+        return loadFileEvents(this.inner, args);
     }
 }
 
@@ -555,7 +541,7 @@ class Seshat {
 class SeshatRecovery {
     constructor(path, config = undefined) {
         config = config || {};
-        this.inner = seshat_recovery_new(path, config);
+        this.inner = seshatNative.createRecoveryDb(path, config);
     }
 
     /**
@@ -565,7 +551,7 @@ class SeshatRecovery {
      * re-indexed events and the done percentage.
      */
     info() {
-        return seshat_recovery_info(this.inner);
+        return seshatNative.getInfoRecoveryDb(this.inner);
     }
 
     /**
@@ -575,7 +561,8 @@ class SeshatRecovery {
      * represents the user version of the database.
      */
     async getUserVersion() {
-	return seshat_recovery_getUserVersion(this.inner);
+        const getUserVersion = promisify(seshatNative.getUserVersionRecoveryDb);
+        return getUserVersion(this.inner);
     }
 
     /**
@@ -585,7 +572,8 @@ class SeshatRecovery {
      * been closed.
      */
     async shutdown() {
-        return seshat_recovery_shutdown(this.inner);
+        const shutdown = promisify(seshatNative.shutdownRecoveryDb);
+        return shutdown(this.inner);
     }
 
     /**
@@ -595,7 +583,8 @@ class SeshatRecovery {
      * been re-indexed.
      */
     async reindex() {
-        return seshat_recovery_reindex(this.inner);
+        const reindex = promisify(seshatNative.reindexRecoveryDb);
+        return reindex(this.inner);
     }
 }
 

--- a/seshat-node/lib/index.js
+++ b/seshat-node/lib/index.js
@@ -554,6 +554,7 @@ class Seshat {
  */
 class SeshatRecovery {
     constructor(path, config = undefined) {
+        config = config || {};
         this.inner = seshat_recovery_new(path, config);
     }
 

--- a/seshat-node/lib/index.js
+++ b/seshat-node/lib/index.js
@@ -139,7 +139,7 @@ class ReindexError extends Error {
  * search can be done on the database retrieving events that match a search
  * query.
  */
-class Seshat extends seshat.Seshat {
+class Seshat {
     /**
      * Open an existing or create a new Seshat database.
      *
@@ -168,7 +168,7 @@ class Seshat extends seshat.Seshat {
     constructor(path, config = undefined) {
         config = config || {};
         try {
-            super(path, config);
+            this.inner = seshat.seshat_new(path, config);
         } catch (e) {
             // The Rust side throws a RangeError, this is a bit silly so convert
             // it to a custom error.
@@ -193,7 +193,7 @@ class Seshat extends seshat.Seshat {
      * @return {Void}
      */
     addEvent(matrixEvent, profile = {}) {
-        return super.addEvent(matrixEvent, profile);
+        return seshat.seshat_addEvent(this.inner, matrixEvent, profile);
     };
 
     /**
@@ -210,7 +210,7 @@ class Seshat extends seshat.Seshat {
      */
     async deleteEvent(eventId) {
         return new Promise((resolve, reject) => {
-            super.deleteEvent(eventId, (err, res) => {
+            seshat.seshat_deleteEvent(this.inner, eventId, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -233,7 +233,7 @@ class Seshat extends seshat.Seshat {
      */
     async commit(force = false) {
         return new Promise((resolve, reject) => {
-            super.commit(force, (err, res) => {
+            seshat.seshat_commit(this.inner, force, (err, res) => {
                 resolve(res);
             });
         });
@@ -253,7 +253,7 @@ class Seshat extends seshat.Seshat {
      * incrementing number that identifies the commit.
      */
     commitSync(wait = false, force = false) {
-        return super.commitSync(wait, force);
+        return seshat.seshat_commitSync(this.inner, wait, force);
     }
 
     /**
@@ -262,7 +262,7 @@ class Seshat extends seshat.Seshat {
      * for unit testing purposes to force a reload before a search.
      */
     reload() {
-        super.reload();
+        seshat.seshat_reload(this.inner);
     };
 
     /**
@@ -289,7 +289,7 @@ class Seshat extends seshat.Seshat {
      */
     async search(args) {
         return new Promise((resolve, reject) => {
-            super.search(args, (err, res) => {
+            seshat.seshat_search(this.inner, args, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -314,7 +314,7 @@ class Seshat extends seshat.Seshat {
      */
     searchSync(term, limit = 10, before_limit = 0, after_limit = 0,
         order_by_recency = false) {
-        return super.searchSync(term, limit, before_limit, after_limit,
+        return seshat.seshat_searchSync(this.inner, term, limit, before_limit, after_limit,
             order_by_recency);
     }
 
@@ -330,7 +330,7 @@ class Seshat extends seshat.Seshat {
      * false otherwise.
      */
     addHistoricEventsSync(events, newCheckpoint = null, oldCheckPoint = null) {
-        return super.addHistoricEventsSync(events, newCheckpoint,
+        return seshat.seshat_addHistoricEventsSync(this.inner, events, newCheckpoint,
             oldCheckPoint);
     }
 
@@ -348,7 +348,8 @@ class Seshat extends seshat.Seshat {
     async addHistoricEvents(events, newCheckpoint = null,
         oldCheckPoint = null) {
         return new Promise((resolve, reject) => {
-            super.addHistoricEvents(
+            seshat.seshat_addHistoricEvents(
+                this.inner,
                 events,
                 newCheckpoint,
                 oldCheckPoint,
@@ -392,7 +393,7 @@ class Seshat extends seshat.Seshat {
      */
     async loadCheckpoints() {
         return new Promise((resolve, reject) => {
-            super.loadCheckpoints((err, res) => {
+            seshat.seshat_loadCheckpoints(this.inner, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -408,7 +409,7 @@ class Seshat extends seshat.Seshat {
      */
     async getSize() {
         return new Promise((resolve, reject) => {
-            super.getSize((err, res) => {
+            seshat.seshat_getSize(this.inner, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -423,7 +424,7 @@ class Seshat extends seshat.Seshat {
      */
     async getStats() {
         return new Promise((resolve, reject) => {
-            super.getStats((err, res) => {
+            seshat.seshat_getStats(this.inner, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -438,7 +439,7 @@ class Seshat extends seshat.Seshat {
      */
     async delete() {
         return new Promise((resolve, reject) => {
-            super.delete((err, res) => {
+            seshat.seshat_delete(this.inner, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -453,7 +454,7 @@ class Seshat extends seshat.Seshat {
      */
     async shutdown() {
         return new Promise((resolve, reject) => {
-            super.shutdown((err, res) => {
+            seshat.seshat_shutdown(this.inner, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -473,7 +474,7 @@ class Seshat extends seshat.Seshat {
      */
     async changePassphrase(newPassphrase) {
         return new Promise((resolve, reject) => {
-            super.changePassphrase(newPassphrase, (err, res) => {
+            seshat.seshat_changePassphrase(this.inner, newPassphrase, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -489,7 +490,7 @@ class Seshat extends seshat.Seshat {
      */
     async isEmpty() {
         return new Promise((resolve, reject) => {
-            super.isEmpty((err, res) => {
+            seshat.seshat_isEmpty(this.inner, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -507,7 +508,7 @@ class Seshat extends seshat.Seshat {
      */
     async isRoomIndexed(roomId) {
         return new Promise((resolve, reject) => {
-            super.isRoomIndexed(roomId, (err, res) => {
+            seshat.seshat_isRoomIndexed(this.inner, roomId, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -522,7 +523,7 @@ class Seshat extends seshat.Seshat {
      */
     async getUserVersion() {
         return new Promise((resolve, reject) => {
-            super.getUserVersion((err, res) => {
+            seshat.seshat_getUserVersion(this.inner, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -540,7 +541,7 @@ class Seshat extends seshat.Seshat {
      */
     async setUserVersion(version) {
         return new Promise((resolve, reject) => {
-            super.setUserVersion(version, (err, res) => {
+            seshat.seshat_setUserVersion(this.inner, version, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -566,7 +567,7 @@ class Seshat extends seshat.Seshat {
      */
     async loadFileEvents(args) {
         return new Promise((resolve, reject) => {
-            super.loadFileEvents(args, (err, res) => {
+            seshat.seshat_loadFileEvents(this.inner, args, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -603,7 +604,11 @@ class Seshat extends seshat.Seshat {
  * // reindex the database
  * await recovery.reindex();
  */
-class SeshatRecovery extends seshat.SeshatRecovery {
+class SeshatRecovery {
+    constructor(path, config = undefined) {
+        this.inner = seshat.seshat_recovery_new(path, config);
+    }
+
     /**
      * Get info about the re-index status.
      *
@@ -611,7 +616,7 @@ class SeshatRecovery extends seshat.SeshatRecovery {
      * re-indexed events and the done percentage.
      */
     info() {
-        return super.info();
+        return seshat.seshat_recovery_info(this.inner);
     }
 
     /**
@@ -622,7 +627,7 @@ class SeshatRecovery extends seshat.SeshatRecovery {
      */
     async getUserVersion() {
         return new Promise((resolve, reject) => {
-            super.getUserVersion((err, res) => {
+            seshat.seshat_recovery_getUserVersion(this.inner, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -637,7 +642,7 @@ class SeshatRecovery extends seshat.SeshatRecovery {
      */
     async shutdown() {
         return new Promise((resolve, reject) => {
-            super.shutdown((err, res) => {
+            seshat.seshat_recovery_shutdown(this.inner, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });
@@ -652,7 +657,7 @@ class SeshatRecovery extends seshat.SeshatRecovery {
      */
     async reindex() {
         return new Promise((resolve, reject) => {
-            super.reindex((err, res) => {
+            seshat.seshat_recovery_reindex(this.inner, (err, res) => {
                 if (err) reject(err);
                 else resolve(res);
             });

--- a/seshat-node/native/Cargo.lock
+++ b/seshat-node/native/Cargo.lock
@@ -1015,7 +1015,7 @@ dependencies = [
 [[package]]
 name = "neon-serde"
 version = "0.4.0"
-source = "git+https://github.com/antonok-edm/neon-serde/?rev=ee44a7e465e8082f7d7e5a7fe2980188930a50cf#ee44a7e465e8082f7d7e5a7fe2980188930a50cf"
+source = "git+https://github.com/matrix-org/neon-serde?rev=ee44a7e465e8082f7d7e5a7fe2980188930a50cf#ee44a7e465e8082f7d7e5a7fe2980188930a50cf"
 dependencies = [
  "error-chain",
  "neon",

--- a/seshat-node/native/Cargo.lock
+++ b/seshat-node/native/Cargo.lock
@@ -54,15 +54,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "739f4a8db6605981345c5654f3a85b056ce52f37a39d34da03f25bf2151ea16e"
 
 [[package]]
-name = "aho-corasick"
-version = "0.7.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7404febffaa47dac81aa44dba71523c9d069b1bdc50a77db41195149e17f68e5"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "atomicwrites"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -820,6 +811,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89203f3fba0a3795506acaad8ebce3c80c0af93f994d5a1d7a0b1eeb23271929"
 
 [[package]]
+name = "libloading"
+version = "0.6.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "351a32417a12d5f7e82c368a66781e307834dae04c6ce0cd4456d52989229883"
+dependencies = [
+ "cfg-if 1.0.0",
+ "winapi 0.3.9",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.20.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -972,57 +973,54 @@ dependencies = [
 
 [[package]]
 name = "neon"
-version = "0.4.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cac4691701b686e6c07b2eb5b51a9f26f5c11179c5d7924b78100dd387fc99d"
+checksum = "7d33fe11bcc59e19cadfabd6a90ac07038eddc357f6effa25a731dd3ae7f40d6"
 dependencies = [
  "cslice",
  "neon-build",
+ "neon-macros",
  "neon-runtime",
  "semver",
+ "smallvec",
 ]
 
 [[package]]
 name = "neon-build"
-version = "0.4.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9ed332afd4711b84f4f83d334428a1fd9ce53620b62b87595934297c5ede2ed"
+checksum = "c6fe902d44ec11ccd34980b5de63b96a79ce96e231de976338166c34c43bd70b"
+
+[[package]]
+name = "neon-macros"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec537080e06fef83443c16fcc354a2168888770705b8cd5bc54a31e9791b777f"
 dependencies = [
- "cfg-if 0.1.10",
- "neon-sys",
+ "quote",
+ "syn",
 ]
 
 [[package]]
 name = "neon-runtime"
-version = "0.4.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2beea093a60c08463f65e1da4cda68149986f60d8d2177489b44589463c782a6"
+checksum = "120205ff046015597a47ab4fd81aa17f9681eae6e6ee5aa49aa3c020bb83ec99"
 dependencies = [
- "cfg-if 0.1.10",
- "neon-sys",
+ "cfg-if 1.0.0",
+ "libloading",
+ "smallvec",
 ]
 
 [[package]]
 name = "neon-serde"
 version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f134307714cdd478581fd3cc990202ead78744d676d8437bdff64260395eb8e"
+source = "git+https://github.com/antonok-edm/neon-serde/?rev=ee44a7e465e8082f7d7e5a7fe2980188930a50cf#ee44a7e465e8082f7d7e5a7fe2980188930a50cf"
 dependencies = [
  "error-chain",
  "neon",
- "neon-runtime",
  "num",
  "serde",
-]
-
-[[package]]
-name = "neon-sys"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69a6c1ba6b926746f4d3f596de18ce49d062d78fd9f35f636080232aa77a0e16"
-dependencies = [
- "cc",
- "regex",
 ]
 
 [[package]]
@@ -1545,10 +1543,7 @@ version = "1.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9251239e129e16308e70d853559389de218ac275b515068abc96829d05b948a"
 dependencies = [
- "aho-corasick",
- "memchr",
  "regex-syntax 0.6.22",
- "thread_local",
 ]
 
 [[package]]
@@ -1682,8 +1677,6 @@ dependencies = [
 [[package]]
 name = "seshat"
 version = "2.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6142bdd2bc11827960ab30b8400568633160129055963d9e7a49ae2f112c8e1"
 dependencies = [
  "aes-ctr",
  "byteorder",
@@ -1713,7 +1706,6 @@ version = "2.2.4"
 dependencies = [
  "fs_extra",
  "neon",
- "neon-build",
  "neon-serde",
  "serde_json",
  "seshat",
@@ -1896,15 +1888,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "thread_local"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb9bc092d0d51e76b2b19d9d85534ffc9ec2db959a2523cdae0697e2972cd447"
-dependencies = [
- "lazy_static",
 ]
 
 [[package]]

--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 fs_extra = "1.2.0"
 serde_json = "1.0.58"
-neon-serde = { git = "https://github.com/antonok-edm/neon-serde/", rev = "ee44a7e465e8082f7d7e5a7fe2980188930a50cf" }
+neon-serde = { git = "https://github.com/matrix-org/neon-serde", rev = "ee44a7e465e8082f7d7e5a7fe2980188930a50cf" }
 uuid = "0.8.1"
 seshat = { version = "2.2.4", path = "../../" }
 

--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -3,7 +3,6 @@ name = "seshat-node"
 version = "2.2.4"
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 license = "Apache-2.0"
-build = "build.rs"
 exclude = ["artifacts.json", "index.node"]
 edition = "2018"
 
@@ -14,13 +13,14 @@ crate-type = ["cdylib"]
 # We are pinning the exact version of neon since it has a track record of
 # introducing breaking changes in patch releases.
 
-[build-dependencies]
-neon-build = "=0.4.0"
-
 [dependencies]
-neon = "=0.4.0"
 fs_extra = "1.2.0"
 serde_json = "1.0.58"
-neon-serde = "=0.4.0"
+neon-serde = { git = "https://github.com/antonok-edm/neon-serde/", rev = "ee44a7e465e8082f7d7e5a7fe2980188930a50cf" }
 uuid = "0.8.1"
 seshat = { version = "2.2.4", path = "../../" }
+
+[dependencies.neon]
+version = "=0.8.2"
+default-features = false
+features = ["napi-4"]

--- a/seshat-node/native/build.rs
+++ b/seshat-node/native/build.rs
@@ -1,7 +1,0 @@
-extern crate neon_build;
-
-fn main() {
-    neon_build::setup(); // must be called in build.rs
-
-    // add project-specific build logic here...
-}

--- a/seshat-node/native/src/lib.rs
+++ b/seshat-node/native/src/lib.rs
@@ -566,7 +566,7 @@ impl Seshat {
         };
 
         let count = ret.count;
-        let results = cx.array_buffer(ret.results.len() as u32)?;
+        let results = JsArray::new(&mut cx, ret.results.len() as u32);
         let count = cx.number(count as f64);
 
         for (i, element) in ret.results.drain(..).enumerate() {
@@ -575,7 +575,7 @@ impl Seshat {
         }
 
         let search_result = cx.empty_object();
-        let highlights = cx.array_buffer(0)?;
+        let highlights = JsArray::new(&mut cx, 0);
 
         search_result.set(&mut cx, "count", count)?;
         search_result.set(&mut cx, "results", results)?;

--- a/seshat-node/native/src/lib.rs
+++ b/seshat-node/native/src/lib.rs
@@ -77,10 +77,8 @@ impl SeshatRecovery {
         let connection = {
             let db = &mut this.borrow_mut().database;
 
-            db.as_mut().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.get_connection()),
-            )
+            db.as_mut()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.get_connection()))
         };
 
         let connection = match connection {
@@ -185,10 +183,8 @@ impl Seshat {
         let connection = {
             let db = &mut this.borrow_mut().database;
 
-            db.as_mut().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.get_connection()),
-            )
+            db.as_mut()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.get_connection()))
         };
 
         let connection = match connection {
@@ -247,10 +243,8 @@ impl Seshat {
 
         let receiver = {
             let db = &mut this.borrow_mut().database;
-            db.as_mut().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.delete_event(&event_id)),
-            )
+            db.as_mut()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.delete_event(&event_id)))
         };
 
         let receiver = match receiver {
@@ -300,10 +294,8 @@ impl Seshat {
 
         let ret = {
             let db = &mut this.borrow_mut().database;
-            db.as_mut().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.reload()),
-            )
+            db.as_mut()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.reload()))
         };
 
         match ret {
@@ -324,10 +316,8 @@ impl Seshat {
         let connection = {
             let db = &mut this.borrow_mut().database;
 
-            db.as_mut().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.get_connection()),
-            )
+            db.as_mut()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.get_connection()))
         };
 
         let connection = match connection {
@@ -352,10 +342,8 @@ impl Seshat {
 
         let path = {
             let db = &mut this.borrow_mut().database;
-            db.as_ref().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.get_path().to_path_buf()),
-            )
+            db.as_ref()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.get_path().to_path_buf()))
         };
 
         let path = match path {
@@ -373,10 +361,8 @@ impl Seshat {
         let connection = {
             let db = &mut this.borrow_mut().database;
 
-            db.as_mut().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.get_connection()),
-            )
+            db.as_mut()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.get_connection()))
         };
 
         let connection = match connection {
@@ -403,10 +389,8 @@ impl Seshat {
         let connection = {
             let db = &mut this.borrow_mut().database;
 
-            db.as_mut().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.get_connection()),
-            )
+            db.as_mut()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.get_connection()))
         };
 
         let connection = match connection {
@@ -435,10 +419,8 @@ impl Seshat {
         let connection = {
             let db = &mut this.borrow_mut().database;
 
-            db.as_mut().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.get_connection()),
-            )
+            db.as_mut()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.get_connection()))
         };
 
         let connection = match connection {
@@ -465,10 +447,8 @@ impl Seshat {
         let connection = {
             let db = &mut this.borrow_mut().database;
 
-            db.as_mut().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.get_connection()),
-            )
+            db.as_mut()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.get_connection()))
         };
 
         let connection = match connection {
@@ -553,10 +533,8 @@ impl Seshat {
 
         let ret = {
             let db = &mut this.borrow_mut().database;
-            db.as_ref().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.search(&term, &config)),
-            )
+            db.as_ref()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.search(&term, &config)))
         };
 
         let ret = match ret {
@@ -601,10 +579,8 @@ impl Seshat {
 
         let searcher = {
             let db = &mut this.borrow_mut().database;
-            db.as_ref().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.get_searcher()),
-            )
+            db.as_ref()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.get_searcher()))
         };
 
         let searcher = match searcher {
@@ -723,10 +699,8 @@ impl Seshat {
 
         let connection = {
             let db = &mut this.borrow_mut().database;
-            db.as_ref().map_or_else(
-                || Err(CLOSED_ERROR),
-                |db| Ok(db.get_connection()),
-            )
+            db.as_ref()
+                .map_or_else(|| Err(CLOSED_ERROR), |db| Ok(db.get_connection()))
         };
 
         let connection = match connection {

--- a/seshat-node/native/src/lib.rs
+++ b/seshat-node/native/src/lib.rs
@@ -748,31 +748,33 @@ impl Seshat {
 
 #[neon::main]
 fn main(mut cx: ModuleContext) -> NeonResult<()> {
-    cx.export_function("seshat_recovery_new", SeshatRecovery::new)?;
-    cx.export_function("seshat_recovery_reindex", SeshatRecovery::reindex)?;
-    cx.export_function("seshat_recovery_getUserVersion", SeshatRecovery::get_user_version)?;
-    cx.export_function("seshat_recovery_shutdown", SeshatRecovery::shutdown)?;
-    cx.export_function("seshat_recovery_info", SeshatRecovery::info)?;
-    cx.export_function("seshat_new", Seshat::new)?;
-    cx.export_function("seshat_addHistoricEventsSync", Seshat::add_historic_events_sync)?;
-    cx.export_function("seshat_addHistoricEvents", Seshat::add_historic_events)?;
-    cx.export_function("seshat_loadCheckpoints", Seshat::load_checkpoints)?;
-    cx.export_function("seshat_addEvent", Seshat::add_event)?;
-    cx.export_function("seshat_deleteEvent", Seshat::delete_event)?;
-    cx.export_function("seshat_commit", Seshat::commit)?;
-    cx.export_function("seshat_reload", Seshat::reload)?;
-    cx.export_function("seshat_getStats", Seshat::get_stats)?;
-    cx.export_function("seshat_getSize", Seshat::get_size)?;
-    cx.export_function("seshat_isEmpty", Seshat::is_empty)?;
-    cx.export_function("seshat_isRoomIndexed", Seshat::is_room_indexed)?;
-    cx.export_function("seshat_getUserVersion", Seshat::get_user_version)?;
-    cx.export_function("seshat_setUserVersion", Seshat::set_user_version)?;
-    cx.export_function("seshat_commitSync", Seshat::commit_sync)?;
-    cx.export_function("seshat_searchSync", Seshat::search_sync)?;
-    cx.export_function("seshat_search", Seshat::search)?;
-    cx.export_function("seshat_delete", Seshat::delete)?;
-    cx.export_function("seshat_changePassphrase", Seshat::change_passphrase)?;
-    cx.export_function("seshat_shutdown", Seshat::shutdown)?;
-    cx.export_function("seshat_loadFileEvents", Seshat::load_file_events)?;
+    cx.export_function("createRecoveryDb", SeshatRecovery::new)?;
+    cx.export_function("reindexRecoveryDb", SeshatRecovery::reindex)?;
+    cx.export_function("getUserVersionRecoveryDb", SeshatRecovery::get_user_version)?;
+    cx.export_function("shutdownRecoveryDb", SeshatRecovery::shutdown)?;
+    cx.export_function("getInfoRecoveryDb", SeshatRecovery::info)?;
+
+    cx.export_function("createDb", Seshat::new)?;
+    cx.export_function("addHistoricEventsSync", Seshat::add_historic_events_sync)?;
+    cx.export_function("addHistoricEvents", Seshat::add_historic_events)?;
+    cx.export_function("loadCheckpoints", Seshat::load_checkpoints)?;
+    cx.export_function("addEvent", Seshat::add_event)?;
+    cx.export_function("deleteEvent", Seshat::delete_event)?;
+    cx.export_function("commit", Seshat::commit)?;
+    cx.export_function("reload", Seshat::reload)?;
+    cx.export_function("getStats", Seshat::get_stats)?;
+    cx.export_function("getSize", Seshat::get_size)?;
+    cx.export_function("isEmpty", Seshat::is_empty)?;
+    cx.export_function("isRoomIndexed", Seshat::is_room_indexed)?;
+    cx.export_function("getUserVersion", Seshat::get_user_version)?;
+    cx.export_function("setUserVersion", Seshat::set_user_version)?;
+    cx.export_function("commitSync", Seshat::commit_sync)?;
+    cx.export_function("searchSync", Seshat::search_sync)?;
+    cx.export_function("search", Seshat::search)?;
+    cx.export_function("deleteDb", Seshat::delete)?;
+    cx.export_function("changePassphrase", Seshat::change_passphrase)?;
+    cx.export_function("shutdown", Seshat::shutdown)?;
+    cx.export_function("loadFileEvents", Seshat::load_file_events)?;
+
     Ok(())
 }

--- a/seshat-node/native/src/lib.rs
+++ b/seshat-node/native/src/lib.rs
@@ -40,8 +40,8 @@ impl Finalize for SeshatRecovery {}
 
 impl SeshatRecovery {
     fn new(mut cx: FunctionContext) -> JsResult<JsBox<RefCell<SeshatRecovery>>> {
-        let db_path: String = cx.argument::<JsString>(2)?.value(&mut cx);
-        let args =  cx.argument_opt(3);
+        let db_path: String = cx.argument::<JsString>(0)?.value(&mut cx);
+        let args =  cx.argument_opt(1);
         let config = parse_database_config(&mut cx, args)?;
         let database = RecoveryDatabase::new_with_config(db_path, &config)
             .expect("Can't open recovery database.");
@@ -64,8 +64,8 @@ impl SeshatRecovery {
     }
 
     fn reindex(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
         let this = cx.argument::<JsBox<RefCell<SeshatRecovery>>>(0)?;
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
 
         let database = {
             let db = &mut this.borrow_mut().database;
@@ -84,8 +84,8 @@ impl SeshatRecovery {
     }
 
     fn get_user_version(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
         let this = cx.argument::<JsBox<RefCell<SeshatRecovery>>>(0)?;
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
 
         let connection = {
             let db = &mut this.borrow_mut().database;
@@ -112,9 +112,8 @@ impl SeshatRecovery {
     }
 
     fn shutdown(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
-
         let this = cx.argument::<JsBox<RefCell<SeshatRecovery>>>(0)?;
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
 
         let database = {
             let db = &mut this.borrow_mut().database;
@@ -154,8 +153,8 @@ impl SeshatRecovery {
 
 impl Seshat {
     fn new(mut cx: FunctionContext) -> JsResult<JsBox<RefCell<Seshat>>> {
-        let db_path: String = cx.argument::<JsString>(1)?.value(&mut cx);
-        let args =  cx.argument_opt(2);
+        let db_path: String = cx.argument::<JsString>(0)?.value(&mut cx);
+        let args =  cx.argument_opt(1);
 
         let config = parse_database_config(&mut cx, args)?;
 
@@ -203,8 +202,8 @@ impl Seshat {
     }
 
     fn add_historic_events(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-        let f = cx.argument::<JsFunction>(3)?.root(&mut cx);
         let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+        let f = cx.argument::<JsFunction>(4)?.root(&mut cx);
         let receiver = add_historic_events_helper(&mut cx)?;
 
         let task = AddBacklogTask { receiver };
@@ -214,8 +213,8 @@ impl Seshat {
     }
 
     fn load_checkpoints(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
         let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
 
         let connection = {
             let db = &mut this.borrow_mut().database;
@@ -242,6 +241,7 @@ impl Seshat {
     }
 
     fn add_event(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
         let event = cx.argument::<JsObject>(1)?;
         let event = parse_event(&mut cx, *event)?;
 
@@ -254,7 +254,6 @@ impl Seshat {
         };
 
         let ret = {
-            let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
             let db = &this.borrow().database;
             db.as_ref().map_or_else(|| Err("Database has been closed or deleted"),
                                     |db| { db.add_event(event, profile); Ok(()) } )
@@ -267,9 +266,9 @@ impl Seshat {
     }
 
     fn delete_event(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
         let event_id = cx.argument::<JsString>(1)?.value(&mut cx);
         let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
-        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
 
         let receiver = {
             let db = &mut this.borrow_mut().database;
@@ -290,13 +289,12 @@ impl Seshat {
     }
 
     fn commit(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
         let force: bool = match cx.argument_opt(1) {
             Some(w) => w.downcast::<JsBoolean, _>(&mut cx).or_throw(&mut cx)?.value(&mut cx),
             None => false,
         };
-
         let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
-        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
 
         let receiver = {
             let db = &mut this.borrow_mut().database;
@@ -342,9 +340,8 @@ impl Seshat {
     }
 
     fn get_stats(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
-
         let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
 
         let connection = {
             let db = &mut this.borrow_mut().database;
@@ -371,9 +368,8 @@ impl Seshat {
     }
 
     fn get_size(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
-
         let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
 
         let path = {
             let db = &mut this.borrow_mut().database;
@@ -393,8 +389,8 @@ impl Seshat {
     }
 
     fn is_empty(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
         let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
 
         let connection = {
             let db = &mut this.borrow_mut().database;
@@ -421,9 +417,9 @@ impl Seshat {
     }
 
     fn is_room_indexed(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
         let room_id = cx.argument::<JsString>(1)?.value(&mut cx);
         let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
-        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
 
         let connection = {
             let db = &mut this.borrow_mut().database;
@@ -450,8 +446,8 @@ impl Seshat {
     }
 
     fn get_user_version(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
         let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
 
         let connection = {
             let db = &mut this.borrow_mut().database;
@@ -478,9 +474,9 @@ impl Seshat {
     }
 
     fn set_user_version(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
         let version = cx.argument::<JsNumber>(1)?;
         let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
-        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
 
         let connection = {
             let db = &mut this.borrow_mut().database;
@@ -507,6 +503,8 @@ impl Seshat {
     }
 
     fn commit_sync(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
         let wait: bool = match cx.argument_opt(1) {
             Some(w) => w.downcast::<JsBoolean, _>(&mut cx).or_throw(&mut cx)?.value(&mut cx),
             None => false,
@@ -516,8 +514,6 @@ impl Seshat {
             Some(w) => w.downcast::<JsBoolean, _>(&mut cx).or_throw(&mut cx)?.value(&mut cx),
             None => false,
         };
-
-        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
 
         let ret = {
             let db = &mut this.borrow_mut().database;
@@ -549,9 +545,9 @@ impl Seshat {
     }
 
     fn search_sync(mut cx: FunctionContext) -> JsResult<JsObject> {
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
         let args = cx.argument::<JsObject>(1)?;
         let (term, config) = parse_search_object(&mut cx, args)?;
-        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
 
         let ret = {
             let db = &mut this.borrow_mut().database;
@@ -594,12 +590,11 @@ impl Seshat {
     }
 
     fn search(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
         let args = cx.argument::<JsObject>(1)?;
         let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
 
         let (term, config) = parse_search_object(&mut cx, args)?;
-
-        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
 
         let searcher = {
             let db = &mut this.borrow_mut().database;
@@ -623,9 +618,8 @@ impl Seshat {
     }
 
     fn delete(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
-
         let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
 
         let db = {
             let db = &mut this.borrow_mut().database;
@@ -650,10 +644,9 @@ impl Seshat {
     }
 
     fn change_passphrase(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
         let new_passphrase = cx.argument::<JsString>(1)?;
         let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
-
-        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
 
         let db = {
             let db = &mut this.borrow_mut().database;
@@ -676,9 +669,8 @@ impl Seshat {
     }
 
     fn shutdown(mut cx: FunctionContext) -> JsResult<JsUndefined> {
-        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
-
         let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
 
         let db = {
             let db = &mut this.borrow_mut().database;
@@ -701,6 +693,7 @@ impl Seshat {
     }
 
     fn load_file_events(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
         let args = cx.argument::<JsObject>(1)?;
         let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
 
@@ -738,8 +731,6 @@ impl Seshat {
                 config = config.direction(direction);
             }
         }
-
-        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
 
         let connection = {
             let db = &mut this.borrow_mut().database;

--- a/seshat-node/native/src/lib.rs
+++ b/seshat-node/native/src/lib.rs
@@ -19,748 +19,782 @@ use neon::prelude::*;
 use seshat::{Database, Error, LoadConfig, LoadDirection, Profile, RecoveryDatabase, RecoveryInfo};
 use std::sync::atomic::Ordering;
 use std::sync::Mutex;
+use std::sync::mpsc;
+use std::cell::RefCell;
 
 use crate::tasks::*;
 use crate::utils::*;
 
-pub struct SeshatDatabase(Option<Database>);
-pub struct SeshatRecoveryDb {
+pub struct Seshat {
+    sender: mpsc::Sender<Box<dyn FnOnce(&EventQueue) + Send + 'static>>,
+    database: Option<Database>,
+}
+pub struct SeshatRecovery {
+    sender: mpsc::Sender<Box<dyn FnOnce(&EventQueue) + Send + 'static>>,
     database: Option<RecoveryDatabase>,
     info: RecoveryInfo,
 }
 
-declare_types! {
-    pub class SeshatRecovery for SeshatRecoveryDb {
-        init(mut cx) {
-            let db_path: String = cx.argument::<JsString>(0)?.value();
-            let args =  cx.argument_opt(1);
-            let config = parse_database_config(&mut cx, args)?;
-            let database = RecoveryDatabase::new_with_config(db_path, &config)
-                .expect("Can't open recovery database.");
-            let info = database.info().clone();
+impl Finalize for Seshat {}
+impl Finalize for SeshatRecovery {}
 
-            Ok(SeshatRecoveryDb{
-                database: Some(database),
-                info
-            })
-        }
+impl SeshatRecovery {
+    fn new(mut cx: FunctionContext) -> JsResult<JsBox<RefCell<SeshatRecovery>>> {
+        let db_path: String = cx.argument::<JsString>(2)?.value(&mut cx);
+        let args =  cx.argument_opt(3);
+        let config = parse_database_config(&mut cx, args)?;
+        let database = RecoveryDatabase::new_with_config(db_path, &config)
+            .expect("Can't open recovery database.");
+        let info = database.info().clone();
 
-        method reindex(mut cx) {
-            let f = cx.argument::<JsFunction>(0)?;
-            let mut this = cx.this();
+        let (tx, rx) = mpsc::channel::<Box<dyn FnOnce(&EventQueue) + Send + 'static>>();
+        let queue = cx.queue();
 
-            let database = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).database;
-                db.take()
-            };
+        std::thread::spawn(move || {
+            while let Ok(message) = rx.recv() {
+                message(&queue);
+            }
+        });
 
-            let database = match database {
-                Some(db) => db,
-                None => return cx.throw_type_error("A reindex has been already done"),
-            };
-
-            let task = ReindexTask { inner: Mutex::new(Some(database)) };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method getUserVersion(mut cx) {
-            let f = cx.argument::<JsFunction>(0)?;
-            let mut this = cx.this();
-
-            let connection = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).database;
-
-                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| Ok(db.get_connection()))
-            };
-
-            let connection = match connection {
-                Ok(c) => match c {
-                    Ok(c) => c,
-                    Err(e) => return cx.throw_type_error(format!(
-                        "Unable to get a database connection {}",
-                        e.to_string()
-                    )),
-                },
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            let task = GetUserVersionTask { connection };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method shutdown(mut cx) {
-            let f = cx.argument::<JsFunction>(0)?;
-
-            let mut this = cx.this();
-
-            let database = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).database;
-                db.take()
-            };
-
-            let task = ShutDownRecoveryDatabaseTask(Mutex::new(database));
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method info(mut cx) {
-            let mut this = cx.this();
-
-            let (total, reindexed) = {
-                let guard = cx.lock();
-                let info = &this.borrow_mut(&guard).info;
-
-                let total = info.total_events();
-                let reindexed = info.reindexed_events().load(Ordering::Relaxed);
-                (total, reindexed)
-            };
-
-            let done: f64 = reindexed as f64 / total as f64;
-            let total = JsNumber::new(&mut cx, total as f64);
-            let reindexed = JsNumber::new(&mut cx, reindexed as f64);
-            let done = JsNumber::new(&mut cx, done);
-
-            let info = JsObject::new(&mut cx);
-            info.set(&mut cx, "totalEvents", total)?;
-            info.set(&mut cx, "reindexedEvents", reindexed)?;
-            info.set(&mut cx, "done", done)?;
-
-            Ok(info.upcast())
-        }
+        Ok(cx.boxed(RefCell::new(SeshatRecovery{
+            database: Some(database),
+            info,
+            sender: tx,
+        })))
     }
 
-    pub class Seshat for SeshatDatabase {
-        init(mut cx) {
-            let db_path: String = cx.argument::<JsString>(0)?.value();
-            let args =  cx.argument_opt(1);
-
-            let config = parse_database_config(&mut cx, args)?;
-
-            let db = match Database::new_with_config(&db_path, &config) {
-                Ok(db) => db,
-                Err(e) => {
-                    // There doesn't seem to be a way to construct custom
-                    // Javascript errors from the Rust side, since we never
-                    // throw a RangeError here, let's hack around this by using
-                    // one here.
-                    let error = match e {
-                        Error::ReindexError => cx.throw_range_error("Database needs to be reindexed"),
-                        e => cx.throw_error(format!("Error opening the database: {:?}", e))
-                    };
-                    return error;
-                }
-            };
-
-            Ok(
-                SeshatDatabase(Some(db))
-           )
-        }
-
-        method addHistoricEventsSync(mut cx) {
-            let receiver = add_historic_events_helper(&mut cx)?;
-            let ret = receiver.recv().unwrap();
-
-            match ret {
-                Ok(r) => Ok(JsBoolean::new(&mut cx, r).upcast()),
-                Err(e) => cx.throw_type_error(e.to_string()),
-            }
-        }
-
-        method addHistoricEvents(mut cx) {
-            let f = cx.argument::<JsFunction>(3)?;
-            let receiver = add_historic_events_helper(&mut cx)?;
-
-            let task = AddBacklogTask { receiver };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method loadCheckpoints(mut cx) {
-            let f = cx.argument::<JsFunction>(0)?;
-            let mut this = cx.this();
-
-            let connection = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-
-                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| Ok(db.get_connection()))
-            };
-
-            let connection = match connection {
-                Ok(c) => match c {
-                    Ok(c) => c,
-                    Err(e) => return cx.throw_type_error(format!(
-                        "Unable to get a database connection {}",
-                        e.to_string()
-                    )),
-                },
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            let task = LoadCheckPointsTask { connection };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method addEvent(mut cx) {
-            let event = cx.argument::<JsObject>(0)?;
-            let event = parse_event(&mut cx, *event)?;
-
-            let profile = match cx.argument_opt(1) {
-                Some(p) => {
-                    let p = p.downcast::<JsObject>().or_throw(&mut cx)?;
-                    parse_profile(&mut cx, *p)?
-                },
-                None => Profile { displayname: None, avatar_url: None },
-            };
-
-            let ret = {
-                let this = cx.this();
-                let guard = cx.lock();
-                let db = &this.borrow(&guard).0;
-                db.as_ref().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| { db.add_event(event, profile); Ok(()) } )
-            };
-
-            match ret {
-                Ok(_) => Ok(cx.undefined().upcast()),
-                Err(e) => cx.throw_type_error(e),
-            }
-        }
-
-        method deleteEvent(mut cx) {
-            let event_id = cx.argument::<JsString>(0)?.value();
-            let f = cx.argument::<JsFunction>(1)?;
-            let mut this = cx.this();
-
-            let receiver = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"), |db| {
-                    Ok(db.delete_event(&event_id))
-                })
-            };
-
-            let receiver = match receiver {
-                Ok(r) => r,
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            let task = DeleteEventTask { receiver };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method commit(mut cx) {
-            let force: bool = match cx.argument_opt(0) {
-                Some(w) => w.downcast::<JsBoolean>().or_throw(&mut cx)?.value(),
-                None => false,
-            };
-
-            let f = cx.argument::<JsFunction>(1)?;
-            let mut this = cx.this();
-
-            let receiver = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"), |db| {
-                    if force {
-                        Ok(db.force_commit_no_wait())
-                    } else {
-                        Ok(db.commit_no_wait())
-                    }
-                })
-            };
-
-            let receiver = match receiver {
-                Ok(r) => r,
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            let task = CommitTask { receiver };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method reload(mut cx) {
-            let mut this = cx.this();
-
-            let ret = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| Ok(db.reload()))
-            };
-
-            match ret {
-                Ok(r) => match r {
-                    Ok(()) => Ok(cx.undefined().upcast()),
-                    Err(e) => {
-                        let message = format!("Error opening the database: {:?}", e);
-                        cx.throw_type_error(message)
-                    }
-                },
-                Err(e) => cx.throw_type_error(e),
-            }
-        }
-
-        method getStats(mut cx) {
-            let f = cx.argument::<JsFunction>(0)?;
-
-            let mut this = cx.this();
-
-            let connection = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-
-                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| Ok(db.get_connection()))
-            };
-
-            let connection = match connection {
-                Ok(c) => match c {
-                    Ok(c) => c,
-                    Err(e) => return cx.throw_type_error(format!(
-                        "Unable to get a database connection {}",
-                        e.to_string()
-                    )),
-                },
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            let task = StatsTask { connection };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method getSize(mut cx) {
-            let f = cx.argument::<JsFunction>(0)?;
-
-            let mut this = cx.this();
-
-            let path = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-                db.as_ref().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| Ok(db.get_path().to_path_buf()))
-            };
-
-            let path = match path {
-                Ok(p) => p,
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            let task = GetSizeTask { path };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method isEmpty(mut cx) {
-            let f = cx.argument::<JsFunction>(0)?;
-            let mut this = cx.this();
-
-            let connection = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-
-                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| Ok(db.get_connection()))
-            };
-
-            let connection = match connection {
-                Ok(c) => match c {
-                    Ok(c) => c,
-                    Err(e) => return cx.throw_type_error(format!(
-                        "Unable to get a database connection {}",
-                        e.to_string()
-                    )),
-                },
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            let task = IsEmptyTask { connection };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method isRoomIndexed(mut cx) {
-            let room_id = cx.argument::<JsString>(0)?.value();
-            let f = cx.argument::<JsFunction>(1)?;
-            let mut this = cx.this();
-
-            let connection = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-
-                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| Ok(db.get_connection()))
-            };
-
-            let connection = match connection {
-                Ok(c) => match c {
-                    Ok(c) => c,
-                    Err(e) => return cx.throw_type_error(format!(
-                        "Unable to get a database connection {}",
-                        e.to_string()
-                    )),
-                },
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            let task = IsRoomIndexedTask { connection, room_id };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method getUserVersion(mut cx) {
-            let f = cx.argument::<JsFunction>(0)?;
-            let mut this = cx.this();
-
-            let connection = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-
-                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| Ok(db.get_connection()))
-            };
-
-            let connection = match connection {
-                Ok(c) => match c {
-                    Ok(c) => c,
-                    Err(e) => return cx.throw_type_error(format!(
-                        "Unable to get a database connection {}",
-                        e.to_string()
-                    )),
-                },
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            let task = GetUserVersionTask { connection };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method setUserVersion(mut cx) {
-            let version = cx.argument::<JsNumber>(0)?;
-            let f = cx.argument::<JsFunction>(1)?;
-            let mut this = cx.this();
-
-            let connection = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-
-                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| Ok(db.get_connection()))
-            };
-
-            let connection = match connection {
-                Ok(c) => match c {
-                    Ok(c) => c,
-                    Err(e) => return cx.throw_type_error(format!(
-                        "Unable to get a database connection {}",
-                        e.to_string()
-                    )),
-                },
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            let task = SetUserVersionTask { connection, new_version: version.value() as i64 };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method commitSync(mut cx) {
-            let wait: bool = match cx.argument_opt(0) {
-                Some(w) => w.downcast::<JsBoolean>().or_throw(&mut cx)?.value(),
-                None => false,
-            };
-
-            let force: bool = match cx.argument_opt(1) {
-                Some(w) => w.downcast::<JsBoolean>().or_throw(&mut cx)?.value(),
-                None => false,
-            };
-
-            let mut this = cx.this();
-
-            let ret = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-
-                if wait {
-                    db.as_mut().map_or_else(|| Err("Database has been closed or deleted"), |db| {
-                        if force {
-                            Ok(Some(db.force_commit()))
-                        } else {
-                            Ok(Some(db.commit()))
-                        }
-                    }
-                   )
-                } else {
-                    db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
-                                            |db| { db.commit_no_wait(); Ok(None) } )
-                }
-            };
-
-            let ret = match ret {
-                Ok(r) => r,
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            match ret {
-                Some(_) => Ok(cx.undefined().upcast()),
-                None => Ok(cx.undefined().upcast())
-            }
-        }
-
-        method searchSync(mut cx) {
-            let args = cx.argument::<JsObject>(0)?;
-            let (term, config) = parse_search_object(&mut cx, args)?;
-            let mut this = cx.this();
-
-            let ret = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-                db.as_ref().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| Ok(db.search(&term, &config)))
-            };
-
-            let ret = match ret {
-                Ok(r) => r,
-                Err(e) => return cx.throw_type_error(e),
-            };
-
-            let mut ret = match ret {
-                Ok(r) => r,
-                Err(e) => return cx.throw_type_error(e.to_string()),
-            };
-
-            let count = ret.count;
-            let results = JsArray::new(&mut cx, ret.results.len() as u32);
-            let count = JsNumber::new(&mut cx, count as f64);
-
-            for (i, element) in ret.results.drain(..).enumerate() {
-                let object = search_result_to_js(&mut cx, element)?;
-                results.set(&mut cx, i as u32, object)?;
-            }
-
-            let search_result = JsObject::new(&mut cx);
-            let highlights = JsArray::new(&mut cx, 0);
-
-            search_result.set(&mut cx, "count", count)?;
-            search_result.set(&mut cx, "results", results)?;
-            search_result.set(&mut cx, "highlights", highlights)?;
-
-            if let Some(next_batch) = ret.next_batch {
-                let next_batch = JsString::new(&mut cx, next_batch.to_hyphenated().to_string());
-                search_result.set(&mut cx, "next_batch", next_batch)?;
-            }
-
-            Ok(search_result.upcast())
-        }
-
-        method search(mut cx) {
-            let args = cx.argument::<JsObject>(0)?;
-            let f = cx.argument::<JsFunction>(1)?;
-
-            let (term, config) = parse_search_object(&mut cx, args)?;
-
-            let mut this = cx.this();
-
-            let searcher = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-                db.as_ref().map_or_else(|| Err("Database has been closed or deleted"),
-                                        |db| Ok(db.get_searcher()))
-            };
-
-            let searcher = match searcher {
-                Ok(s) => s,
-                Err(e) => return cx.throw_type_error(e.to_string()),
-            };
-
-            let task = SearchTask {
-                inner: searcher,
-                term,
-                config
-            };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method delete(mut cx) {
-            let f = cx.argument::<JsFunction>(0)?;
-
-            let mut this = cx.this();
-
-            let db = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-                db.take()
-            };
-
-            let db = match db {
-                Some(db) => db,
-                None => return cx.throw_type_error("Database has been closed or deleted")
-            };
-
-            let db_path = db.get_path().to_path_buf();
-            let receiver = db.shutdown();
-
-            let task = DeleteTask {
-                db_path,
-                shutdown_receiver: receiver,
-            };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method changePassphrase(mut cx) {
-            let new_passphrase = cx.argument::<JsString>(0)?;
-            let f = cx.argument::<JsFunction>(1)?;
-
-            let mut this = cx.this();
-
-            let db = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-                db.take()
-            };
-
-            let db = match db {
-                Some(db) => db,
-                None => return cx.throw_type_error("Database has been closed or deleted")
-            };
-
-            let task = ChangePassphraseTask {
-                database: Mutex::new(Some(db)),
-                new_passphrase: new_passphrase.value(),
-            };
-
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method shutdown(mut cx) {
-            let f = cx.argument::<JsFunction>(0)?;
-
-            let mut this = cx.this();
-
-            let db = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-                db.take()
-            };
-
-            let db = match db {
-                Some(db) => db,
-                None => return cx.throw_type_error("Database has been closed or deleted")
-            };
-
-            let receiver = db.shutdown();
-
-            let task = ShutDownTask {
-                shutdown_receiver: receiver,
-            };
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
-
-        method loadFileEvents(mut cx) {
-            let args = cx.argument::<JsObject>(0)?;
-            let f = cx.argument::<JsFunction>(1)?;
-
-            let room_id = args
-                    .get(&mut cx, "roomId")?
-                    .downcast::<JsString>()
-                    .or_throw(&mut cx)?
-                    .value();
-
-            let mut config = LoadConfig::new(room_id);
-
-            let limit = args
-                    .get(&mut cx, "limit")?
-                    .downcast::<JsNumber>()
-                    .or_throw(&mut cx)?
-                    .value();
-
-            config = config.limit(limit as usize);
-
-            if let Ok(e) = args.get(&mut cx, "fromEvent") {
-                if let Ok(e) = e.downcast::<JsString>() {
-                    config = config.from_event(e.value());
-                }
-            };
-
-            if let Ok(d) = args.get(&mut cx, "direction") {
-                if let Ok(e) = d.downcast::<JsString>() {
-                    let direction = match e.value().to_lowercase().as_ref() {
-                        "backwards" | "backward" | "b" => LoadDirection::Backwards,
-                        "forwards" | "forward" | "f" => LoadDirection::Forwards,
-                        "" => LoadDirection::Backwards,
-                        d => return cx.throw_error(format!("Unknown load direction {}", d)),
-                    };
-
-                    config = config.direction(direction);
-                }
-            }
-
-            let mut this = cx.this();
-
-            let connection = {
-                let guard = cx.lock();
-                let db = &mut this.borrow_mut(&guard).0;
-                db
-                    .as_ref()
-                    .map_or_else(|| Err("Database has been closed or deleted"),
-                                 |db| Ok(db.get_connection()))
-            };
-
-            let connection = match connection {
-                Ok(s) => match s {
-                    Ok(s) => s,
-                    Err(e) => return cx.throw_type_error(e.to_string()),
-                },
-                Err(e) => return cx.throw_type_error(e.to_string()),
-            };
-
-            let task = LoadFileEventsTask {
-                inner: connection,
-                config,
-            };
-
-            task.schedule(f);
-
-            Ok(cx.undefined().upcast())
-        }
+    fn reindex(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
+        let this = cx.argument::<JsBox<RefCell<SeshatRecovery>>>(0)?;
+
+        let database = {
+            let db = &mut this.borrow_mut().database;
+            db.take()
+        };
+
+        let database = match database {
+            Some(db) => db,
+            None => return cx.throw_type_error("A reindex has been already done"),
+        };
+
+        let task = ReindexTask { inner: Mutex::new(Some(database)) };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn get_user_version(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
+        let this = cx.argument::<JsBox<RefCell<SeshatRecovery>>>(0)?;
+
+        let connection = {
+            let db = &mut this.borrow_mut().database;
+
+            db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| Ok(db.get_connection()))
+        };
+
+        let connection = match connection {
+            Ok(c) => match c {
+                Ok(c) => c,
+                Err(e) => return cx.throw_type_error(format!(
+                    "Unable to get a database connection {}",
+                    e.to_string()
+                )),
+            },
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        let task = GetUserVersionTask { connection };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn shutdown(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
+
+        let this = cx.argument::<JsBox<RefCell<SeshatRecovery>>>(0)?;
+
+        let database = {
+            let db = &mut this.borrow_mut().database;
+            db.take()
+        };
+
+        let task = ShutDownRecoveryDatabaseTask(Mutex::new(database));
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn info(mut cx: FunctionContext) -> JsResult<JsObject> {
+        let this = cx.argument::<JsBox<RefCell<SeshatRecovery>>>(0)?;
+
+        let (total, reindexed) = {
+            let info = &this.borrow_mut().info;
+
+            let total = info.total_events();
+            let reindexed = info.reindexed_events().load(Ordering::Relaxed);
+            (total, reindexed)
+        };
+
+        let done: f64 = reindexed as f64 / total as f64;
+        let total = cx.number(total as f64);
+        let reindexed = cx.number(reindexed as f64);
+        let done = cx.number(done);
+
+        let info = cx.empty_object();
+        info.set(&mut cx, "totalEvents", total)?;
+        info.set(&mut cx, "reindexedEvents", reindexed)?;
+        info.set(&mut cx, "done", done)?;
+
+        Ok(info.upcast())
     }
 }
 
-register_module!(mut cx, {
-    cx.export_class::<Seshat>("Seshat")?;
-    cx.export_class::<SeshatRecovery>("SeshatRecovery")?;
+impl Seshat {
+    fn new(mut cx: FunctionContext) -> JsResult<JsBox<RefCell<Seshat>>> {
+        let db_path: String = cx.argument::<JsString>(1)?.value(&mut cx);
+        let args =  cx.argument_opt(2);
+
+        let config = parse_database_config(&mut cx, args)?;
+
+        let db = match Database::new_with_config(&db_path, &config) {
+            Ok(db) => db,
+            Err(e) => {
+                // There doesn't seem to be a way to construct custom
+                // Javascript errors from the Rust side, since we never
+                // throw a RangeError here, let's hack around this by using
+                // one here.
+                let error = match e {
+                    Error::ReindexError => cx.throw_range_error("Database needs to be reindexed"),
+                    e => cx.throw_error(format!("Error opening the database: {:?}", e))
+                };
+                return error;
+            }
+        };
+
+        let (tx, rx) = mpsc::channel::<Box<dyn FnOnce(&EventQueue) + Send + 'static>>();
+        let queue = cx.queue();
+
+        std::thread::spawn(move || {
+            while let Ok(message) = rx.recv() {
+                message(&queue);
+            }
+        });
+
+
+        Ok(cx.boxed(RefCell::new(
+            Seshat {
+                database: Some(db),
+                sender: tx,
+            }
+        )))
+    }
+
+    fn add_historic_events_sync(mut cx: FunctionContext) -> JsResult<JsBoolean> {
+        let receiver = add_historic_events_helper(&mut cx)?;
+        let ret = receiver.recv().unwrap();
+
+        match ret {
+            Ok(r) => Ok(cx.boolean(r)),
+            Err(e) => cx.throw_type_error(e.to_string()),
+        }
+    }
+
+    fn add_historic_events(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let f = cx.argument::<JsFunction>(3)?.root(&mut cx);
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+        let receiver = add_historic_events_helper(&mut cx)?;
+
+        let task = AddBacklogTask { receiver };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn load_checkpoints(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let connection = {
+            let db = &mut this.borrow_mut().database;
+
+            db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| Ok(db.get_connection()))
+        };
+
+        let connection = match connection {
+            Ok(c) => match c {
+                Ok(c) => c,
+                Err(e) => return cx.throw_type_error(format!(
+                    "Unable to get a database connection {}",
+                    e.to_string()
+                )),
+            },
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        let task = LoadCheckPointsTask { connection };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn add_event(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let event = cx.argument::<JsObject>(1)?;
+        let event = parse_event(&mut cx, *event)?;
+
+        let profile = match cx.argument_opt(2) {
+            Some(p) => {
+                let p = p.downcast::<JsObject, _>(&mut cx).or_throw(&mut cx)?;
+                parse_profile(&mut cx, *p)?
+            },
+            None => Profile { displayname: None, avatar_url: None },
+        };
+
+        let ret = {
+            let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+            let db = &this.borrow().database;
+            db.as_ref().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| { db.add_event(event, profile); Ok(()) } )
+        };
+
+        match ret {
+            Ok(_) => Ok(cx.undefined()),
+            Err(e) => cx.throw_type_error(e),
+        }
+    }
+
+    fn delete_event(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let event_id = cx.argument::<JsString>(1)?.value(&mut cx);
+        let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let receiver = {
+            let db = &mut this.borrow_mut().database;
+            db.as_mut().map_or_else(|| Err("Database has been closed or deleted"), |db| {
+                Ok(db.delete_event(&event_id))
+            })
+        };
+
+        let receiver = match receiver {
+            Ok(r) => r,
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        let task = DeleteEventTask { receiver };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn commit(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let force: bool = match cx.argument_opt(1) {
+            Some(w) => w.downcast::<JsBoolean, _>(&mut cx).or_throw(&mut cx)?.value(&mut cx),
+            None => false,
+        };
+
+        let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let receiver = {
+            let db = &mut this.borrow_mut().database;
+            db.as_mut().map_or_else(|| Err("Database has been closed or deleted"), |db| {
+                if force {
+                    Ok(db.force_commit_no_wait())
+                } else {
+                    Ok(db.commit_no_wait())
+                }
+            })
+        };
+
+        let receiver = match receiver {
+            Ok(r) => r,
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        let task = CommitTask { receiver };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn reload(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let ret = {
+            let db = &mut this.borrow_mut().database;
+            db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| Ok(db.reload()))
+        };
+
+        match ret {
+            Ok(r) => match r {
+                Ok(()) => Ok(cx.undefined()),
+                Err(e) => {
+                    let message = format!("Error opening the database: {:?}", e);
+                    cx.throw_type_error(message)
+                }
+            },
+            Err(e) => cx.throw_type_error(e),
+        }
+    }
+
+    fn get_stats(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
+
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let connection = {
+            let db = &mut this.borrow_mut().database;
+
+            db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| Ok(db.get_connection()))
+        };
+
+        let connection = match connection {
+            Ok(c) => match c {
+                Ok(c) => c,
+                Err(e) => return cx.throw_type_error(format!(
+                    "Unable to get a database connection {}",
+                    e.to_string()
+                )),
+            },
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        let task = StatsTask { connection };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn get_size(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
+
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let path = {
+            let db = &mut this.borrow_mut().database;
+            db.as_ref().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| Ok(db.get_path().to_path_buf()))
+        };
+
+        let path = match path {
+            Ok(p) => p,
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        let task = GetSizeTask { path };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn is_empty(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let connection = {
+            let db = &mut this.borrow_mut().database;
+
+            db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| Ok(db.get_connection()))
+        };
+
+        let connection = match connection {
+            Ok(c) => match c {
+                Ok(c) => c,
+                Err(e) => return cx.throw_type_error(format!(
+                    "Unable to get a database connection {}",
+                    e.to_string()
+                )),
+            },
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        let task = IsEmptyTask { connection };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn is_room_indexed(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let room_id = cx.argument::<JsString>(1)?.value(&mut cx);
+        let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let connection = {
+            let db = &mut this.borrow_mut().database;
+
+            db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| Ok(db.get_connection()))
+        };
+
+        let connection = match connection {
+            Ok(c) => match c {
+                Ok(c) => c,
+                Err(e) => return cx.throw_type_error(format!(
+                    "Unable to get a database connection {}",
+                    e.to_string()
+                )),
+            },
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        let task = IsRoomIndexedTask { connection, room_id };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn get_user_version(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let connection = {
+            let db = &mut this.borrow_mut().database;
+
+            db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| Ok(db.get_connection()))
+        };
+
+        let connection = match connection {
+            Ok(c) => match c {
+                Ok(c) => c,
+                Err(e) => return cx.throw_type_error(format!(
+                    "Unable to get a database connection {}",
+                    e.to_string()
+                )),
+            },
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        let task = GetUserVersionTask { connection };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn set_user_version(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let version = cx.argument::<JsNumber>(1)?;
+        let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let connection = {
+            let db = &mut this.borrow_mut().database;
+
+            db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| Ok(db.get_connection()))
+        };
+
+        let connection = match connection {
+            Ok(c) => match c {
+                Ok(c) => c,
+                Err(e) => return cx.throw_type_error(format!(
+                    "Unable to get a database connection {}",
+                    e.to_string()
+                )),
+            },
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        let task = SetUserVersionTask { connection, new_version: version.value(&mut cx) as i64 };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn commit_sync(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let wait: bool = match cx.argument_opt(1) {
+            Some(w) => w.downcast::<JsBoolean, _>(&mut cx).or_throw(&mut cx)?.value(&mut cx),
+            None => false,
+        };
+
+        let force: bool = match cx.argument_opt(2) {
+            Some(w) => w.downcast::<JsBoolean, _>(&mut cx).or_throw(&mut cx)?.value(&mut cx),
+            None => false,
+        };
+
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let ret = {
+            let db = &mut this.borrow_mut().database;
+
+            if wait {
+                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"), |db| {
+                    if force {
+                        Ok(Some(db.force_commit()))
+                    } else {
+                        Ok(Some(db.commit()))
+                    }
+                }
+               )
+            } else {
+                db.as_mut().map_or_else(|| Err("Database has been closed or deleted"),
+                                        |db| { db.commit_no_wait(); Ok(None) } )
+            }
+        };
+
+        let ret = match ret {
+            Ok(r) => r,
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        match ret {
+            Some(_) => Ok(cx.undefined()),
+            None => Ok(cx.undefined())
+        }
+    }
+
+    fn search_sync(mut cx: FunctionContext) -> JsResult<JsObject> {
+        let args = cx.argument::<JsObject>(1)?;
+        let (term, config) = parse_search_object(&mut cx, args)?;
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let ret = {
+            let db = &mut this.borrow_mut().database;
+            db.as_ref().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| Ok(db.search(&term, &config)))
+        };
+
+        let ret = match ret {
+            Ok(r) => r,
+            Err(e) => return cx.throw_type_error(e),
+        };
+
+        let mut ret = match ret {
+            Ok(r) => r,
+            Err(e) => return cx.throw_type_error(e.to_string()),
+        };
+
+        let count = ret.count;
+        let results = cx.array_buffer(ret.results.len() as u32)?;
+        let count = cx.number(count as f64);
+
+        for (i, element) in ret.results.drain(..).enumerate() {
+            let object = search_result_to_js(&mut cx, element)?;
+            results.set(&mut cx, i as u32, object)?;
+        }
+
+        let search_result = cx.empty_object();
+        let highlights = cx.array_buffer(0)?;
+
+        search_result.set(&mut cx, "count", count)?;
+        search_result.set(&mut cx, "results", results)?;
+        search_result.set(&mut cx, "highlights", highlights)?;
+
+        if let Some(next_batch) = ret.next_batch {
+            let next_batch = cx.string(next_batch.to_hyphenated().to_string());
+            search_result.set(&mut cx, "next_batch", next_batch)?;
+        }
+
+        Ok(search_result.upcast())
+    }
+
+    fn search(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let args = cx.argument::<JsObject>(1)?;
+        let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
+
+        let (term, config) = parse_search_object(&mut cx, args)?;
+
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let searcher = {
+            let db = &mut this.borrow_mut().database;
+            db.as_ref().map_or_else(|| Err("Database has been closed or deleted"),
+                                    |db| Ok(db.get_searcher()))
+        };
+
+        let searcher = match searcher {
+            Ok(s) => s,
+            Err(e) => return cx.throw_type_error(e.to_string()),
+        };
+
+        let task = SearchTask {
+            inner: searcher,
+            term,
+            config
+        };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn delete(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
+
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let db = {
+            let db = &mut this.borrow_mut().database;
+            db.take()
+        };
+
+        let db = match db {
+            Some(db) => db,
+            None => return cx.throw_type_error("Database has been closed or deleted")
+        };
+
+        let db_path = db.get_path().to_path_buf();
+        let receiver = db.shutdown();
+
+        let task = DeleteTask {
+            db_path,
+            shutdown_receiver: receiver,
+        };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn change_passphrase(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let new_passphrase = cx.argument::<JsString>(1)?;
+        let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
+
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let db = {
+            let db = &mut this.borrow_mut().database;
+            db.take()
+        };
+
+        let db = match db {
+            Some(db) => db,
+            None => return cx.throw_type_error("Database has been closed or deleted")
+        };
+
+        let task = ChangePassphraseTask {
+            database: Mutex::new(Some(db)),
+            new_passphrase: new_passphrase.value(&mut cx),
+        };
+    
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn shutdown(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let f = cx.argument::<JsFunction>(1)?.root(&mut cx);
+
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let db = {
+            let db = &mut this.borrow_mut().database;
+            db.take()
+        };
+
+        let db = match db {
+            Some(db) => db,
+            None => return cx.throw_type_error("Database has been closed or deleted")
+        };
+
+        let receiver = db.shutdown();
+
+        let task = ShutDownTask {
+            shutdown_receiver: receiver,
+        };
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+
+    fn load_file_events(mut cx: FunctionContext) -> JsResult<JsUndefined> {
+        let args = cx.argument::<JsObject>(1)?;
+        let f = cx.argument::<JsFunction>(2)?.root(&mut cx);
+
+        let room_id = args
+                .get(&mut cx, "roomId")?
+                .downcast::<JsString, _>(&mut cx)
+                .or_throw(&mut cx)?
+                .value(&mut cx);
+
+        let mut config = LoadConfig::new(room_id);
+
+        let limit = args
+                .get(&mut cx, "limit")?
+                .downcast::<JsNumber, _>(&mut cx)
+                .or_throw(&mut cx)?
+                .value(&mut cx);
+
+        config = config.limit(limit as usize);
+
+        if let Ok(e) = args.get(&mut cx, "fromEvent") {
+            if let Ok(e) = e.downcast::<JsString, _>(&mut cx) {
+                config = config.from_event(e.value(&mut cx));
+            }
+        };
+
+        if let Ok(d) = args.get(&mut cx, "direction") {
+            if let Ok(e) = d.downcast::<JsString, _>(&mut cx) {
+                let direction = match e.value(&mut cx).to_lowercase().as_ref() {
+                    "backwards" | "backward" | "b" => LoadDirection::Backwards,
+                    "forwards" | "forward" | "f" => LoadDirection::Forwards,
+                    "" => LoadDirection::Backwards,
+                    d => return cx.throw_error(format!("Unknown load direction {}", d)),
+                };
+
+                config = config.direction(direction);
+            }
+        }
+
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+
+        let connection = {
+            let db = &mut this.borrow_mut().database;
+            db
+                .as_ref()
+                .map_or_else(|| Err("Database has been closed or deleted"),
+                             |db| Ok(db.get_connection()))
+        };
+
+        let connection = match connection {
+            Ok(s) => match s {
+                Ok(s) => s,
+                Err(e) => return cx.throw_type_error(e.to_string()),
+            },
+            Err(e) => return cx.throw_type_error(e.to_string()),
+        };
+
+        let task = LoadFileEventsTask {
+            inner: connection,
+            config,
+        };
+    
+        task.schedule(this.borrow().sender.clone(), f).or_else(|err| cx.throw_error(err.to_string()))?;
+
+        Ok(cx.undefined())
+    }
+}
+
+#[neon::main]
+fn main(mut cx: ModuleContext) -> NeonResult<()> {
+    cx.export_function("seshat_recovery_new", SeshatRecovery::new)?;
+    cx.export_function("seshat_recovery_reindex", SeshatRecovery::reindex)?;
+    cx.export_function("seshat_recovery_getUserVersion", SeshatRecovery::get_user_version)?;
+    cx.export_function("seshat_recovery_shutdown", SeshatRecovery::shutdown)?;
+    cx.export_function("seshat_recovery_info", SeshatRecovery::info)?;
+    cx.export_function("seshat_new", Seshat::new)?;
+    cx.export_function("seshat_addHistoricEventsSync", Seshat::add_historic_events_sync)?;
+    cx.export_function("seshat_addHistoricEvents", Seshat::add_historic_events)?;
+    cx.export_function("seshat_loadCheckpoints", Seshat::load_checkpoints)?;
+    cx.export_function("seshat_addEvent", Seshat::add_event)?;
+    cx.export_function("seshat_deleteEvent", Seshat::delete_event)?;
+    cx.export_function("seshat_commit", Seshat::commit)?;
+    cx.export_function("seshat_reload", Seshat::reload)?;
+    cx.export_function("seshat_getStats", Seshat::get_stats)?;
+    cx.export_function("seshat_getSize", Seshat::get_size)?;
+    cx.export_function("seshat_isEmpty", Seshat::is_empty)?;
+    cx.export_function("seshat_isRoomIndexed", Seshat::is_room_indexed)?;
+    cx.export_function("seshat_getUserVersion", Seshat::get_user_version)?;
+    cx.export_function("seshat_setUserVersion", Seshat::set_user_version)?;
+    cx.export_function("seshat_commitSync", Seshat::commit_sync)?;
+    cx.export_function("seshat_searchSync", Seshat::search_sync)?;
+    cx.export_function("seshat_search", Seshat::search)?;
+    cx.export_function("seshat_delete", Seshat::delete)?;
+    cx.export_function("seshat_changePassphrase", Seshat::change_passphrase)?;
+    cx.export_function("seshat_shutdown", Seshat::shutdown)?;
+    cx.export_function("seshat_loadFileEvents", Seshat::load_file_events)?;
     Ok(())
-});
+}

--- a/seshat-node/native/src/tasks.rs
+++ b/seshat-node/native/src/tasks.rs
@@ -114,7 +114,7 @@ impl Task for SearchTask {
             Err(e) => return cx.throw_type_error(e.to_string()),
         };
 
-        let results = cx.array_buffer(ret.results.len() as u32)?;
+        let results = JsArray::new(&mut cx, ret.results.len() as u32);
         let count = cx.number(ret.count as f64);
 
         for (i, element) in ret.results.drain(..).enumerate() {
@@ -123,7 +123,7 @@ impl Task for SearchTask {
         }
 
         let search_result = cx.empty_object();
-        let highlights = cx.array_buffer(0)?;
+        let highlights = JsArray::new(&mut cx, 0);
 
         search_result.set(&mut cx, "count", count)?;
         search_result.set(&mut cx, "results", results)?;
@@ -170,7 +170,7 @@ pub(crate) struct LoadCheckPointsTask {
 impl Task for LoadCheckPointsTask {
     type Output = Vec<CrawlerCheckpoint>;
     type Error = seshat::Error;
-    type JsEvent = JsArrayBuffer;
+    type JsEvent = JsArray;
 
     fn perform(&self) -> Result<Self::Output, Self::Error> {
         self.connection.load_checkpoints()
@@ -186,7 +186,7 @@ impl Task for LoadCheckPointsTask {
             Err(e) => return cx.throw_type_error(e.to_string()),
         };
         let count = checkpoints.len();
-        let ret = cx.array_buffer(count as u32)?;
+        let ret = JsArray::new(&mut cx, count as u32);
 
         for (i, c) in checkpoints.drain(..).enumerate() {
             let js_checkpoint = cx.empty_object();
@@ -383,7 +383,7 @@ pub(crate) struct LoadFileEventsTask {
 impl Task for LoadFileEventsTask {
     type Output = Vec<(String, Profile)>;
     type Error = seshat::Error;
-    type JsEvent = JsArrayBuffer;
+    type JsEvent = JsArray;
 
     fn perform(&self) -> Result<Self::Output, Self::Error> {
         self.inner.load_file_events(&self.config)
@@ -399,7 +399,7 @@ impl Task for LoadFileEventsTask {
             Err(e) => return cx.throw_type_error(e.to_string()),
         };
 
-        let results = cx.array_buffer(ret.len() as u32)?;
+        let results = JsArray::new(&mut cx, ret.len() as u32);
 
         for (i, (source, profile)) in ret.drain(..).enumerate() {
             let result = cx.empty_object();

--- a/seshat-node/native/src/utils.rs
+++ b/seshat-node/native/src/utils.rs
@@ -14,14 +14,12 @@
 
 use crate::Seshat;
 use neon::prelude::*;
-use neon_serde;
-use serde_json;
 use seshat::{
     CheckpointDirection, Config, CrawlerCheckpoint, Event, EventType, Language, Profile, Receiver,
     SearchConfig, SearchResult,
 };
-use uuid::Uuid;
 use std::cell::RefCell;
+use uuid::Uuid;
 
 pub(crate) fn parse_database_config(
     cx: &mut FunctionContext,
@@ -38,7 +36,7 @@ pub(crate) fn parse_database_config(
                 match language {
                     Language::Unknown => {
                         let value = l.value(cx);
-                        return cx.throw_type_error(format!("Unsuported language: {}", value))
+                        return cx.throw_type_error(format!("Unsuported language: {}", value));
                     }
                     _ => {
                         config = config.set_language(&language);
@@ -118,7 +116,10 @@ pub(crate) fn parse_search_object(
             let mut keys: Vec<Handle<JsValue>> = k.to_vec(&mut *cx)?;
 
             for key in keys.drain(..) {
-                let key = key.downcast::<JsString, _>(cx).or_throw(&mut *cx)?.value(cx);
+                let key = key
+                    .downcast::<JsString, _>(cx)
+                    .or_throw(&mut *cx)?
+                    .value(cx);
                 match key.as_ref() {
                     "content.body" => config.with_key(EventType::Message),
                     "content.topic" => config.with_key(EventType::Topic),
@@ -165,7 +166,10 @@ pub(crate) fn add_historic_events_helper(
     for obj in js_events.drain(..) {
         let obj = obj.downcast::<JsObject, _>(cx).or_throw(cx)?;
 
-        let event = obj.get(cx, "event")?.downcast::<JsObject, _>(cx).or_throw(cx)?;
+        let event = obj
+            .get(cx, "event")?
+            .downcast::<JsObject, _>(cx)
+            .or_throw(cx)?;
         let event = parse_event(cx, *event)?;
 
         let profile: Profile = match obj.get(cx, "profile") {
@@ -430,17 +434,21 @@ pub(crate) fn parse_profile(
     cx: &mut FunctionContext,
     profile: JsObject,
 ) -> Result<Profile, neon::result::Throw> {
-    let displayname: Option<String> =
-        match profile.get(&mut *cx, "displayname")?.downcast::<JsString, _>(cx) {
-            Ok(s) => Some(s.value(cx)),
-            Err(_e) => None,
-        };
+    let displayname: Option<String> = match profile
+        .get(&mut *cx, "displayname")?
+        .downcast::<JsString, _>(cx)
+    {
+        Ok(s) => Some(s.value(cx)),
+        Err(_e) => None,
+    };
 
-    let avatar_url: Option<String> =
-        match profile.get(&mut *cx, "avatar_url")?.downcast::<JsString, _>(cx) {
-            Ok(s) => Some(s.value(cx)),
-            Err(_e) => None,
-        };
+    let avatar_url: Option<String> = match profile
+        .get(&mut *cx, "avatar_url")?
+        .downcast::<JsString, _>(cx)
+    {
+        Ok(s) => Some(s.value(cx)),
+        Err(_e) => None,
+    };
 
     Ok(Profile {
         displayname,

--- a/seshat-node/native/src/utils.rs
+++ b/seshat-node/native/src/utils.rs
@@ -239,8 +239,8 @@ pub(crate) fn search_result_to_js<'a, C: Context<'a>>(
     let object = cx.empty_object();
     let context = cx.empty_object();
 
-    let before = cx.array_buffer(result.events_before.len() as u32)?;
-    let after = cx.array_buffer(result.events_after.len() as u32)?;
+    let before = JsArray::new(cx, result.events_before.len() as u32);
+    let after = JsArray::new(cx, result.events_after.len() as u32);
     let profile_info = cx.empty_object();
 
     for (i, event) in result.events_before.iter().enumerate() {

--- a/seshat-node/native/src/utils.rs
+++ b/seshat-node/native/src/utils.rs
@@ -21,22 +21,24 @@ use seshat::{
     SearchConfig, SearchResult,
 };
 use uuid::Uuid;
+use std::cell::RefCell;
 
 pub(crate) fn parse_database_config(
-    cx: &mut CallContext<JsUndefined>,
+    cx: &mut FunctionContext,
     argument: Option<Handle<JsValue>>,
 ) -> Result<Config, neon::result::Throw> {
     let mut config = Config::new();
 
     if let Some(c) = argument {
-        let c = c.downcast::<JsObject>().or_throw(&mut *cx)?;
+        let c = c.downcast::<JsObject, _>(cx).or_throw(&mut *cx)?;
 
         if let Ok(l) = c.get(&mut *cx, "language") {
-            if let Ok(l) = l.downcast::<JsString>() {
-                let language = Language::from(l.value().as_ref());
+            if let Ok(l) = l.downcast::<JsString, _>(cx) {
+                let language = Language::from(l.value(cx).as_ref());
                 match language {
                     Language::Unknown => {
-                        return cx.throw_type_error(format!("Unsuported language: {}", l.value()))
+                        let value = l.value(cx);
+                        return cx.throw_type_error(format!("Unsuported language: {}", value))
                     }
                     _ => {
                         config = config.set_language(&language);
@@ -46,8 +48,8 @@ pub(crate) fn parse_database_config(
         }
 
         if let Ok(p) = c.get(&mut *cx, "passphrase") {
-            if let Ok(p) = p.downcast::<JsString>() {
-                let passphrase: String = p.value();
+            if let Ok(p) = p.downcast::<JsString, _>(cx) {
+                let passphrase: String = p.value(cx);
                 config = config.set_passphrase(passphrase);
             }
         }
@@ -57,53 +59,54 @@ pub(crate) fn parse_database_config(
 }
 
 pub(crate) fn parse_search_object(
-    cx: &mut CallContext<Seshat>,
+    cx: &mut FunctionContext,
     argument: Handle<JsObject>,
 ) -> Result<(String, SearchConfig), neon::result::Throw> {
     let term = argument
         .get(&mut *cx, "search_term")?
-        .downcast::<JsString>()
+        .downcast::<JsString, _>(cx)
         .or_throw(&mut *cx)?
-        .value();
+        .value(cx);
 
     let mut config = SearchConfig::new();
 
     if let Ok(v) = argument.get(&mut *cx, "limit") {
-        if let Ok(v) = v.downcast::<JsNumber>() {
-            config.limit(v.value() as usize);
+        if let Ok(v) = v.downcast::<JsNumber, _>(cx) {
+            config.limit(v.value(cx) as usize);
         }
     }
 
     if let Ok(v) = argument.get(&mut *cx, "before_limit") {
-        if let Ok(v) = v.downcast::<JsNumber>() {
-            config.before_limit(v.value() as usize);
+        if let Ok(v) = v.downcast::<JsNumber, _>(cx) {
+            config.before_limit(v.value(cx) as usize);
         }
     }
 
     if let Ok(v) = argument.get(&mut *cx, "after_limit") {
-        if let Ok(v) = v.downcast::<JsNumber>() {
-            config.after_limit(v.value() as usize);
+        if let Ok(v) = v.downcast::<JsNumber, _>(cx) {
+            config.after_limit(v.value(cx) as usize);
         }
     }
 
     if let Ok(v) = argument.get(&mut *cx, "order_by_recency") {
-        if let Ok(v) = v.downcast::<JsBoolean>() {
-            config.order_by_recency(v.value());
+        if let Ok(v) = v.downcast::<JsBoolean, _>(cx) {
+            config.order_by_recency(v.value(cx));
         }
     }
 
     if let Ok(r) = argument.get(&mut *cx, "room_id") {
-        if let Ok(r) = r.downcast::<JsString>() {
-            config.for_room(&r.value());
+        if let Ok(r) = r.downcast::<JsString, _>(cx) {
+            config.for_room(&r.value(cx));
         }
     }
 
     if let Ok(t) = argument.get(&mut *cx, "next_batch") {
-        if let Ok(t) = t.downcast::<JsString>() {
-            let token = if let Ok(t) = Uuid::parse_str(&t.value()) {
+        if let Ok(t) = t.downcast::<JsString, _>(cx) {
+            let token = if let Ok(t) = Uuid::parse_str(&t.value(cx)) {
                 t
             } else {
-                return cx.throw_type_error(format!("Invalid next_batch token {}", t.value()));
+                let value = t.value(cx);
+                return cx.throw_type_error(format!("Invalid next_batch token {}", value));
             };
 
             config.next_batch(token);
@@ -111,11 +114,11 @@ pub(crate) fn parse_search_object(
     }
 
     if let Ok(k) = argument.get(&mut *cx, "keys") {
-        if let Ok(k) = k.downcast::<JsArray>() {
+        if let Ok(k) = k.downcast::<JsArray, _>(cx) {
             let mut keys: Vec<Handle<JsValue>> = k.to_vec(&mut *cx)?;
 
             for key in keys.drain(..) {
-                let key = key.downcast::<JsString>().or_throw(&mut *cx)?.value();
+                let key = key.downcast::<JsString, _>(cx).or_throw(&mut *cx)?.value(cx);
                 match key.as_ref() {
                     "content.body" => config.with_key(EventType::Message),
                     "content.topic" => config.with_key(EventType::Topic),
@@ -130,14 +133,14 @@ pub(crate) fn parse_search_object(
 }
 
 pub(crate) fn parse_checkpoint(
-    cx: &mut CallContext<Seshat>,
+    cx: &mut FunctionContext,
     argument: Option<Handle<JsValue>>,
 ) -> Result<Option<CrawlerCheckpoint>, neon::result::Throw> {
     match argument {
-        Some(c) => match c.downcast::<JsObject>() {
+        Some(c) => match c.downcast::<JsObject, _>(cx) {
             Ok(object) => Ok(Some(js_checkpoint_to_rust(cx, *object)?)),
             Err(_e) => {
-                let _o = c.downcast::<JsNull>().or_throw(cx)?;
+                let _o = c.downcast::<JsNull, _>(cx).or_throw(cx)?;
                 Ok(None)
             }
         },
@@ -146,28 +149,28 @@ pub(crate) fn parse_checkpoint(
 }
 
 pub(crate) fn add_historic_events_helper(
-    cx: &mut CallContext<Seshat>,
+    cx: &mut FunctionContext,
 ) -> Result<Receiver<seshat::Result<bool>>, neon::result::Throw> {
-    let js_events = cx.argument::<JsArray>(0)?;
+    let js_events = cx.argument::<JsArray>(1)?;
     let mut js_events: Vec<Handle<JsValue>> = js_events.to_vec(cx)?;
 
-    let js_checkpoint = cx.argument_opt(1);
+    let js_checkpoint = cx.argument_opt(2);
     let new_checkpoint: Option<CrawlerCheckpoint> = parse_checkpoint(cx, js_checkpoint)?;
 
-    let js_checkpoint = cx.argument_opt(2);
+    let js_checkpoint = cx.argument_opt(3);
     let old_checkpoint: Option<CrawlerCheckpoint> = parse_checkpoint(cx, js_checkpoint)?;
 
     let mut events: Vec<(Event, Profile)> = Vec::new();
 
     for obj in js_events.drain(..) {
-        let obj = obj.downcast::<JsObject>().or_throw(cx)?;
+        let obj = obj.downcast::<JsObject, _>(cx).or_throw(cx)?;
 
-        let event = obj.get(cx, "event")?.downcast::<JsObject>().or_throw(cx)?;
+        let event = obj.get(cx, "event")?.downcast::<JsObject, _>(cx).or_throw(cx)?;
         let event = parse_event(cx, *event)?;
 
         let profile: Profile = match obj.get(cx, "profile") {
             Ok(p) => {
-                if let Ok(p) = p.downcast::<JsObject>() {
+                if let Ok(p) = p.downcast::<JsObject, _>(cx) {
                     parse_profile(cx, *p)?
                 } else {
                     Profile {
@@ -186,9 +189,8 @@ pub(crate) fn add_historic_events_helper(
     }
 
     let receiver = {
-        let this = cx.this();
-        let guard = cx.lock();
-        let db = &this.borrow(&guard).0;
+        let this = cx.argument::<JsBox<RefCell<Seshat>>>(0)?;
+        let db = &this.borrow_mut().database;
         db.as_ref().map_or_else(
             || Err("Database has been deleted"),
             |db| Ok(db.add_historic_events(events, new_checkpoint, old_checkpoint)),
@@ -218,7 +220,11 @@ pub(crate) fn deserialize_event<'a, C: Context<'a>>(
         }
     };
 
-    let ret = neon_serde::to_value(&mut *cx, &source)?;
+    let ret = match neon_serde::to_value(&mut *cx, &source) {
+        Ok(v) => v,
+        Err(e) => return cx.throw_error::<_, _>(e.to_string()),
+    };
+
     Ok(ret)
 }
 
@@ -228,14 +234,14 @@ pub(crate) fn search_result_to_js<'a, C: Context<'a>>(
 ) -> Result<Handle<'a, JsObject>, neon::result::Throw> {
     let rank = cx.number(f64::from(result.score));
 
-    let event = deserialize_event(&mut *cx, &result.event_source)?;
+    let event = deserialize_event(cx, &result.event_source)?;
 
-    let object = JsObject::new(&mut *cx);
-    let context = JsObject::new(&mut *cx);
+    let object = cx.empty_object();
+    let context = cx.empty_object();
 
-    let before = JsArray::new(&mut *cx, result.events_before.len() as u32);
-    let after = JsArray::new(&mut *cx, result.events_after.len() as u32);
-    let profile_info = JsObject::new(&mut *cx);
+    let before = cx.array_buffer(result.events_before.len() as u32)?;
+    let after = cx.array_buffer(result.events_after.len() as u32)?;
+    let profile_info = cx.empty_object();
 
     for (i, event) in result.events_before.iter().enumerate() {
         let js_event = serde_json::from_str(event);
@@ -243,7 +249,10 @@ pub(crate) fn search_result_to_js<'a, C: Context<'a>>(
             Ok(e) => e,
             Err(_) => continue,
         };
-        let js_event = neon_serde::to_value(&mut *cx, &js_event)?;
+        let js_event = match neon_serde::to_value(&mut *cx, &js_event) {
+            Ok(v) => v,
+            Err(e) => return cx.throw_error::<_, _>(e.to_string()),
+        };
         before.set(&mut *cx, i as u32, js_event)?;
     }
 
@@ -253,7 +262,10 @@ pub(crate) fn search_result_to_js<'a, C: Context<'a>>(
             Ok(e) => e,
             Err(_) => continue,
         };
-        let js_event = neon_serde::to_value(&mut *cx, &js_event)?;
+        let js_event = match neon_serde::to_value(&mut *cx, &js_event) {
+            Ok(v) => v,
+            Err(e) => return cx.throw_error::<_, _>(e.to_string()),
+        };
         after.set(&mut *cx, i as u32, js_event)?;
     }
 
@@ -277,25 +289,27 @@ pub(crate) fn profile_to_js<'a, C: Context<'a>>(
     cx: &mut C,
     profile: Profile,
 ) -> Result<Handle<'a, JsObject>, neon::result::Throw> {
-    let js_profile = JsObject::new(&mut *cx);
+    let js_profile = cx.empty_object();
 
     match profile.displayname {
         Some(name) => {
-            let js_name = JsString::new(&mut *cx, name);
+            let js_name = cx.string(name);
             js_profile.set(&mut *cx, "displayname", js_name)?;
         }
         None => {
-            js_profile.set(&mut *cx, "displayname", JsNull::new())?;
+            let null = cx.null();
+            js_profile.set(&mut *cx, "displayname", null)?;
         }
     }
 
     match profile.avatar_url {
         Some(avatar) => {
-            let js_avatar = JsString::new(&mut *cx, avatar);
+            let js_avatar = cx.string(avatar);
             js_profile.set(&mut *cx, "avatar_url", js_avatar)?;
         }
         None => {
-            js_profile.set(&mut *cx, "avatar_url", JsNull::new())?;
+            let null = cx.null();
+            js_profile.set(&mut *cx, "avatar_url", null)?;
         }
     }
 
@@ -307,50 +321,50 @@ pub(crate) fn sender_and_profile_to_js<'a, C: Context<'a>>(
     sender: String,
     profile: Profile,
 ) -> Result<(Handle<'a, JsString>, Handle<'a, JsObject>), neon::result::Throw> {
-    let js_sender = JsString::new(&mut *cx, sender);
+    let js_sender = cx.string(sender);
     let js_profile = profile_to_js(cx, profile)?;
 
     Ok((js_sender, js_profile))
 }
 
 pub(crate) fn parse_event(
-    cx: &mut CallContext<Seshat>,
+    cx: &mut FunctionContext,
     event: JsObject,
 ) -> Result<Event, neon::result::Throw> {
     let sender: String = event
         .get(&mut *cx, "sender")?
-        .downcast::<JsString>()
+        .downcast::<JsString, _>(cx)
         .or_else(|_| cx.throw_type_error("Event doesn't contain a valid sender"))?
-        .value();
+        .value(cx);
 
     let event_id: String = event
         .get(&mut *cx, "event_id")?
-        .downcast::<JsString>()
+        .downcast::<JsString, _>(cx)
         .or_else(|_| cx.throw_type_error("Event doesn't contain a valid event id"))?
-        .value();
+        .value(cx);
 
     let server_timestamp: i64 = event
         .get(&mut *cx, "origin_server_ts")?
-        .downcast::<JsNumber>()
+        .downcast::<JsNumber, _>(cx)
         .or_else(|_| cx.throw_type_error("Event doesn't contain a valid timestamp"))?
-        .value() as i64;
+        .value(cx) as i64;
 
     let room_id: String = event
         .get(&mut *cx, "room_id")?
-        .downcast::<JsString>()
+        .downcast::<JsString, _>(cx)
         .or_else(|_| cx.throw_type_error("Event doesn't contain a valid room id"))?
-        .value();
+        .value(cx);
 
     let content = event
         .get(&mut *cx, "content")?
-        .downcast::<JsObject>()
+        .downcast::<JsObject, _>(cx)
         .or_else(|_| cx.throw_type_error("Event doesn't contain any content"))?;
 
     let event_type = event
         .get(&mut *cx, "type")?
-        .downcast::<JsString>()
+        .downcast::<JsString, _>(cx)
         .or_else(|_| cx.throw_type_error("Event doesn't contain a valid type"))?
-        .value();
+        .value(cx);
 
     let event_type: EventType = match event_type.as_ref() {
         "m.room.message" => EventType::Message,
@@ -362,38 +376,41 @@ pub(crate) fn parse_event(
     let content_value = match event_type {
         EventType::Message => content
             .get(&mut *cx, "body")?
-            .downcast::<JsString>()
+            .downcast::<JsString, _>(cx)
             .or_else(|_| cx.throw_type_error("Event doesn't contain a valid body"))?
-            .value(),
+            .value(cx),
 
         EventType::Topic => content
             .get(&mut *cx, "topic")?
-            .downcast::<JsString>()
+            .downcast::<JsString, _>(cx)
             .or_else(|_| cx.throw_type_error("Event doesn't contain a valid topic"))?
-            .value(),
+            .value(cx),
 
         EventType::Name => content
             .get(&mut *cx, "name")?
-            .downcast::<JsString>()
+            .downcast::<JsString, _>(cx)
             .or_else(|_| cx.throw_type_error("Event doesn't contain a valid name"))?
-            .value(),
+            .value(cx),
     };
 
     let msgtype = match event_type {
         EventType::Message => Some(
             content
                 .get(&mut *cx, "msgtype")?
-                .downcast::<JsString>()
+                .downcast::<JsString, _>(cx)
                 .or_else(|_| {
                     cx.throw_type_error("m.room.message event doesn't contain a valid msgtype")
                 })?
-                .value(),
+                .value(cx),
         ),
         _ => None,
     };
 
     let event_value = event.as_value(&mut *cx);
-    let event_source: serde_json::Value = neon_serde::from_value(&mut *cx, event_value)?;
+    let event_source: serde_json::Value = match neon_serde::from_value(&mut *cx, event_value) {
+        Ok(v) => v,
+        Err(e) => return cx.throw_error::<_, _>(e.to_string()),
+    };
     let event_source: String = serde_json::to_string(&event_source)
         .or_else(|e| cx.throw_type_error(format!("Cannot serialize event {}", e)))?;
 
@@ -410,18 +427,18 @@ pub(crate) fn parse_event(
 }
 
 pub(crate) fn parse_profile(
-    cx: &mut CallContext<Seshat>,
+    cx: &mut FunctionContext,
     profile: JsObject,
 ) -> Result<Profile, neon::result::Throw> {
     let displayname: Option<String> =
-        match profile.get(&mut *cx, "displayname")?.downcast::<JsString>() {
-            Ok(s) => Some(s.value()),
+        match profile.get(&mut *cx, "displayname")?.downcast::<JsString, _>(cx) {
+            Ok(s) => Some(s.value(cx)),
             Err(_e) => None,
         };
 
     let avatar_url: Option<String> =
-        match profile.get(&mut *cx, "avatar_url")?.downcast::<JsString>() {
-            Ok(s) => Some(s.value()),
+        match profile.get(&mut *cx, "avatar_url")?.downcast::<JsString, _>(cx) {
+            Ok(s) => Some(s.value(cx)),
             Err(_e) => None,
         };
 
@@ -432,29 +449,29 @@ pub(crate) fn parse_profile(
 }
 
 pub(crate) fn js_checkpoint_to_rust(
-    cx: &mut CallContext<Seshat>,
+    cx: &mut FunctionContext,
     object: JsObject,
 ) -> Result<CrawlerCheckpoint, neon::result::Throw> {
     let room_id = object
         .get(&mut *cx, "roomId")?
-        .downcast::<JsString>()
+        .downcast::<JsString, _>(cx)
         .or_throw(&mut *cx)?
-        .value();
+        .value(cx);
     let token = object
         .get(&mut *cx, "token")?
-        .downcast::<JsString>()
+        .downcast::<JsString, _>(cx)
         .or_throw(&mut *cx)?
-        .value();
+        .value(cx);
     let full_crawl: bool = object
         .get(&mut *cx, "fullCrawl")?
-        .downcast::<JsBoolean>()
-        .unwrap_or_else(|_| JsBoolean::new(&mut *cx, false))
-        .value();
+        .downcast::<JsBoolean, _>(cx)
+        .unwrap_or_else(|_| cx.boolean(false))
+        .value(cx);
     let direction = object
         .get(&mut *cx, "direction")?
-        .downcast::<JsString>()
-        .unwrap_or_else(|_| JsString::new(&mut *cx, ""))
-        .value();
+        .downcast::<JsString, _>(cx)
+        .unwrap_or_else(|_| cx.string(""))
+        .value(cx);
 
     let direction = match direction.to_lowercase().as_ref() {
         "backwards" | "backward" | "b" => CheckpointDirection::Backwards,

--- a/seshat-node/package.json
+++ b/seshat-node/package.json
@@ -6,7 +6,7 @@
   "author": "Damir Jelić <poljar@termina.org.uk>",
   "license": "Apache-2.0",
   "dependencies": {
-    "neon-cli": "^0.3.3"
+    "neon-cli": "^0.8.2"
   },
   "devDependencies": {
     "eslint": "^6.2.2",

--- a/seshat-node/test/test.js
+++ b/seshat-node/test/test.js
@@ -426,7 +426,7 @@ describe('Database', function() {
 
         expect(() => db
             .addEvent(matrixEvent, matrixProfileOnlyDisplayName))
-            .toThrow('Database has been closed or deleted');
+            .toThrow(TypeError('Database has been closed or deleted'));
     });
 
     it('should allow us to check if the db is empty', async function() {
@@ -598,23 +598,25 @@ describe('Database', function() {
 
     it('should throw an error when adding events with missing fields.', function() {
         delete matrixEvent.content;
-        expect(() => db.addEvent(matrixEvent, matrixProfile)).toThrow('Event doesn\'t contain any content');
+        expect(() => db.addEvent(matrixEvent, matrixProfile)).toThrow(TypeError('Event doesn\'t contain any content'));
 
         delete matrixEvent.room_id;
-        expect(() => db.addEvent(matrixEvent, matrixProfile)).toThrow('Event doesn\'t contain a valid room id');
+        expect(() => db.addEvent(matrixEvent, matrixProfile)).toThrow(TypeError('Event doesn\'t contain a valid room id'));
 
         delete matrixEvent.origin_server_ts;
-        expect(() => db.addEvent(matrixEvent, matrixProfile)).toThrow('Event doesn\'t contain a valid timestamp');
+        expect(() => db.addEvent(matrixEvent, matrixProfile)).toThrow(TypeError('Event doesn\'t contain a valid timestamp'));
 
         delete matrixEvent.event_id;
-        expect(() => db.addEvent(matrixEvent, matrixProfile)).toThrow('Event doesn\'t contain a valid event id');
+        expect(() => db.addEvent(matrixEvent, matrixProfile)).toThrow(TypeError('Event doesn\'t contain a valid event id'));
 
         delete matrixEvent.sender;
-        expect(() => db.addEvent(matrixEvent, matrixProfile)).toThrow('Event doesn\'t contain a valid sender');
+        expect(() => db.addEvent(matrixEvent, matrixProfile)).toThrow(TypeError('Event doesn\'t contain a valid sender'));
     });
 
     it('should throw an error when adding events with fields that don\'t typecheck.', function() {
-        expect(() => db.addEvent(badEvent, matrixProfile)).toThrow('Event doesn\'t contain a valid timestamp');
+        const db = createDb();
+
+        expect(() => db.addEvent(badEvent, matrixProfile)).toThrow(TypeError('Event doesn\'t contain a valid timestamp'));
     });
 
     it('should allow us to reindex a database', async function() {

--- a/seshat-node/yarn.lock
+++ b/seshat-node/yarn.lock
@@ -468,13 +468,6 @@ ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
     json-schema-traverse "^0.4.1"
     uri-js "^4.2.2"
 
-ansi-escape-sequences@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/ansi-escape-sequences/-/ansi-escape-sequences-4.1.0.tgz#2483c8773f50dd9174dd9557e92b1718f1816097"
-  integrity sha512-dzW9kHxH011uBsidTXd14JXgzye/YLb2LzeKZ4bsgl/Knwx8AtbSFkkGxagdNOoh0DlqHCmfiEjWKBaqjOanVw==
-  dependencies:
-    array-back "^3.0.1"
-
 ansi-escapes@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-3.2.0.tgz#8780b98ff9dbf5638152d1f1fe5c1d7b4442976b"
@@ -502,7 +495,7 @@ ansi-regex@^5.0.0:
   resolved "https://registry.yarnpkg.com/ansi-regex/-/ansi-regex-5.0.0.tgz#388539f55179bf39339c81af30a654d69f87cb75"
   integrity sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
 
-ansi-styles@^3.1.0, ansi-styles@^3.2.0, ansi-styles@^3.2.1:
+ansi-styles@^3.2.0, ansi-styles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-3.2.1.tgz#41fbb20243e50b12be0f04b8dedbf07520ce841d"
   integrity sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
@@ -547,24 +540,15 @@ arr-union@^3.1.0:
   resolved "https://registry.yarnpkg.com/arr-union/-/arr-union-3.1.0.tgz#e39b09aea9def866a8f206e288af63919bae39c4"
   integrity sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
 
-array-back@^1.0.3, array-back@^1.0.4:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/array-back/-/array-back-1.0.4.tgz#644ba7f095f7ffcf7c43b5f0dc39d3c1f03c063b"
-  integrity sha1-ZEun8JX3/898Q7Xw3DnTwfA8Bjs=
-  dependencies:
-    typical "^2.6.0"
-
-array-back@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/array-back/-/array-back-2.0.0.tgz#6877471d51ecc9c9bfa6136fb6c7d5fe69748022"
-  integrity sha512-eJv4pLLufP3g5kcZry0j6WXpIbzYw9GUB4mVJZno9wfwiBxbizTnHCw3VJb07cBihbFX48Y7oSrW9y+gt4glyw==
-  dependencies:
-    typical "^2.6.1"
-
 array-back@^3.0.1:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/array-back/-/array-back-3.1.0.tgz#b8859d7a508871c9a7b2cf42f99428f65e96bfb0"
   integrity sha512-TkuxA4UCOvxuDK6NZYXCalszEzj+TLszyASooky+i742l9TqsOdYCMJJupxRic61hwquNtppB3hgcuq9SVSH1Q==
+
+array-back@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/array-back/-/array-back-4.0.2.tgz#8004e999a6274586beeb27342168652fdb89fa1e"
+  integrity sha512-NbdMezxqf94cnNfWLL7V/im0Ub+Anbb0IoZhvzie8+4HJ4nMQuzHuy49FkGYCJK2yAloZ3meiB6AVMClbrI1vg==
 
 array-equal@^1.0.0:
   version "1.0.0"
@@ -812,19 +796,13 @@ chalk@^3.0.0:
     ansi-styles "^4.1.0"
     supports-color "^7.1.0"
 
-chalk@~2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
-  integrity sha512-LUHGS/dge4ujbXMJrnihYMcL4AoOweGnw9Tp3kQuqy1Kx5c1qKjqvMJZ6nVJPMWJtKCTN72ZogH3oeSO9g9rXQ==
+chalk@^4.1.0:
+  version "4.1.1"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.1.tgz#c80b3fab28bf6371e6863325eee67e618b77e6ad"
+  integrity sha512-diHzdDKxcU+bAsUboHLPEDQiw0qEe0qd7SYUn3HgcFlWgbDcfLGswOHYeGrHKzG9z6UYf01d9VFMfZxPM1xZSg==
   dependencies:
-    ansi-styles "^3.1.0"
-    escape-string-regexp "^1.0.5"
-    supports-color "^4.0.0"
-
-chardet@^0.4.0:
-  version "0.4.2"
-  resolved "https://registry.yarnpkg.com/chardet/-/chardet-0.4.2.tgz#b5473b33dc97c424e5d98dc87d55d4d8a29c8bf2"
-  integrity sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=
+    ansi-styles "^4.1.0"
+    supports-color "^7.1.0"
 
 chardet@^0.7.0:
   version "0.7.0"
@@ -846,13 +824,6 @@ class-utils@^0.3.5:
     isobject "^3.0.0"
     static-extend "^0.1.1"
 
-cli-cursor@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
-  integrity sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
-  dependencies:
-    restore-cursor "^2.0.0"
-
 cli-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/cli-cursor/-/cli-cursor-3.1.0.tgz#264305a7ae490d1d03bf0c9ba7c925d1753af307"
@@ -864,6 +835,11 @@ cli-width@^2.0.0:
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
   integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
+
+cli-width@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-3.0.0.tgz#a2f48437a2caa9a22436e794bf071ec9e61cedf6"
+  integrity sha512-FxqpkPPwu1HjuN93Omfm4h8uIanXofW0RxVEW3k5RKx+mJJYSthzNhp32Kzxxy3YAEZ/Dc/EWN1vZRY0+kOhbw==
 
 cliui@^5.0.0:
   version "5.0.0"
@@ -918,31 +894,32 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
-command-line-args@^4.0.2:
-  version "4.0.7"
-  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-4.0.7.tgz#f8d1916ecb90e9e121eda6428e41300bfb64cc46"
-  integrity sha512-aUdPvQRAyBvQd2n7jXcsMDz68ckBJELXNzBybCHOibUWEg0mWTnaYCSRU8h9R+aNRSvDihJtssSRCiDRpLaezA==
+command-line-args@^5.1.1:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/command-line-args/-/command-line-args-5.1.1.tgz#88e793e5bb3ceb30754a86863f0401ac92fd369a"
+  integrity sha512-hL/eG8lrll1Qy1ezvkant+trihbGnaKaeEjj6Scyr3DN+RC7iQ5Rz84IeLERfAWDGo0HBSNAakczwgCilDXnWg==
   dependencies:
-    array-back "^2.0.0"
-    find-replace "^1.0.3"
-    typical "^2.6.1"
+    array-back "^3.0.1"
+    find-replace "^3.0.0"
+    lodash.camelcase "^4.3.0"
+    typical "^4.0.0"
 
-command-line-commands@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/command-line-commands/-/command-line-commands-2.0.1.tgz#c58aa13dc78c06038ed67077e57ad09a6f858f46"
-  integrity sha512-m8c2p1DrNd2ruIAggxd/y6DgygQayf6r8RHwchhXryaLF8I6koYjoYroVP+emeROE9DXN5b9sP1Gh+WtvTTdtQ==
+command-line-commands@^3.0.1:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/command-line-commands/-/command-line-commands-3.0.2.tgz#53872a1181db837f21906b1228e260a4eeb42ee4"
+  integrity sha512-ac6PdCtdR6q7S3HN+JiVLIWGHY30PRYIEl2qPo+FuEuzwAUk0UYyimrngrg7FvF/mCr4Jgoqv5ZnHZgads50rw==
   dependencies:
-    array-back "^2.0.0"
+    array-back "^4.0.1"
 
-command-line-usage@^4.0.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-4.1.0.tgz#a6b3b2e2703b4dcf8bd46ae19e118a9a52972882"
-  integrity sha512-MxS8Ad995KpdAC0Jopo/ovGIroV/m0KHwzKfXxKag6FHOkGsH8/lv5yjgablcRxCJJC0oJeUMuO/gmaq+Wq46g==
+command-line-usage@^6.1.0:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/command-line-usage/-/command-line-usage-6.1.1.tgz#c908e28686108917758a49f45efb4f02f76bc03f"
+  integrity sha512-F59pEuAR9o1SF/bD0dQBDluhpT4jJQNWUHEuVBqpDmCUo6gPjCi+m9fCWnWZVR/oG6cMTUms4h+3NPl74wGXvA==
   dependencies:
-    ansi-escape-sequences "^4.0.0"
-    array-back "^2.0.0"
-    table-layout "^0.4.2"
-    typical "^2.6.1"
+    array-back "^4.0.1"
+    chalk "^2.4.2"
+    table-layout "^1.0.1"
+    typical "^5.2.0"
 
 commander@~2.20.3:
   version "2.20.3"
@@ -1371,15 +1348,6 @@ extend@~3.0.2:
   resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
   integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
 
-external-editor@^2.0.4:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-2.2.0.tgz#045511cfd8d133f3846673d1047c154e214ad3d5"
-  integrity sha512-bSn6gvGxKt+b7+6TKEv1ZycHleA7aHhRHyAqJyp5pbUFuYYNIzpZnQDk7AsYckyWdEnTeAnay0aCy2aV6iTk9A==
-  dependencies:
-    chardet "^0.4.0"
-    iconv-lite "^0.4.17"
-    tmp "^0.0.33"
-
 external-editor@^3.0.3:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/external-editor/-/external-editor-3.1.0.tgz#cb03f740befae03ea4d283caed2741a83f335495"
@@ -1435,13 +1403,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-figures@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
-  integrity sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
-  dependencies:
-    escape-string-regexp "^1.0.5"
-
 figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -1471,13 +1432,12 @@ fill-range@^4.0.0:
     repeat-string "^1.6.1"
     to-regex-range "^2.1.0"
 
-find-replace@^1.0.3:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-1.0.3.tgz#b88e7364d2d9c959559f388c66670d6130441fa0"
-  integrity sha1-uI5zZNLZyVlVnziMZmcNYTBEH6A=
+find-replace@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/find-replace/-/find-replace-3.0.0.tgz#3e7e23d3b05167a76f770c9fbd5258b0def68c38"
+  integrity sha512-6Tb2myMioCAgv5kfvP5/PkZZ/ntTpVK39fHY7WkWBgvbeE+VHd/tZuZ4mrC+bxh4cfOZeYKVPaJIZtZXV7GNCQ==
   dependencies:
-    array-back "^1.0.4"
-    test-value "^2.1.0"
+    array-back "^3.0.1"
 
 find-up@^3.0.0:
   version "3.0.0"
@@ -1626,10 +1586,10 @@ growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.1.0:
-  version "4.7.6"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.6.tgz#d4c05c1baf90e9945f77aa68a7a219aa4a7df74e"
-  integrity sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==
+handlebars@^4.7.6:
+  version "4.7.7"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.7.7.tgz#9ce33416aad02dbd6c8fafa8240d5d98004945a1"
+  integrity sha512-aAcXm5OAfE/8IXkcZvCepKU3VzW1/39Fb5ZuqMtgI/hT8X2YgoMvBY5dLhq/cpOvw7Lk1nK/UF71aLG/ZnVYRA==
   dependencies:
     minimist "^1.2.5"
     neo-async "^2.6.0"
@@ -1650,11 +1610,6 @@ har-validator@~5.1.3:
   dependencies:
     ajv "^6.5.5"
     har-schema "^2.0.0"
-
-has-flag@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
-  integrity sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -1735,7 +1690,7 @@ http-signature@~1.2.0:
     jsprim "^1.2.2"
     sshpk "^1.7.0"
 
-iconv-lite@0.4.24, iconv-lite@^0.4.17, iconv-lite@^0.4.24:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -1786,26 +1741,6 @@ iniparser@~1.0.5:
   resolved "https://registry.yarnpkg.com/iniparser/-/iniparser-1.0.5.tgz#836d6befe6dfbfcee0bccf1cf9f2acc7027f783d"
   integrity sha1-g21r7+bfv87gvM8c+fKsxwJ/eD0=
 
-inquirer@^3.0.6:
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"
-  integrity sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==
-  dependencies:
-    ansi-escapes "^3.0.0"
-    chalk "^2.0.0"
-    cli-cursor "^2.1.0"
-    cli-width "^2.0.0"
-    external-editor "^2.0.4"
-    figures "^2.0.0"
-    lodash "^4.3.0"
-    mute-stream "0.0.7"
-    run-async "^2.2.0"
-    rx-lite "^4.0.8"
-    rx-lite-aggregates "^4.0.8"
-    string-width "^2.1.0"
-    strip-ansi "^4.0.0"
-    through "^2.3.6"
-
 inquirer@^7.0.0:
   version "7.1.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.1.0.tgz#1298a01859883e17c7264b82870ae1034f92dd29"
@@ -1821,6 +1756,25 @@ inquirer@^7.0.0:
     mute-stream "0.0.8"
     run-async "^2.4.0"
     rxjs "^6.5.3"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
+inquirer@^7.3.3:
+  version "7.3.3"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
+  integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.0"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.19"
+    mute-stream "0.0.8"
+    run-async "^2.4.0"
+    rxjs "^6.6.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
@@ -2626,20 +2580,25 @@ locate-path@^3.0.0:
     p-locate "^3.0.0"
     path-exists "^3.0.0"
 
-lodash.padend@^4.6.1:
-  version "4.6.1"
-  resolved "https://registry.yarnpkg.com/lodash.padend/-/lodash.padend-4.6.1.tgz#53ccba047d06e158d311f45da625f4e49e6f166e"
-  integrity sha1-U8y6BH0G4VjTEfRdpiX05J5vFm4=
+lodash.camelcase@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
+  integrity sha1-soqmKIorn8ZRA1x3EfZathkDMaY=
 
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.3.0:
+lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
   version "4.17.19"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
   integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
+
+lodash@^4.17.19:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loose-envify@^1.0.0:
   version "1.4.0"
@@ -2648,6 +2607,13 @@ loose-envify@^1.0.0:
   dependencies:
     js-tokens "^3.0.0 || ^4.0.0"
 
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+  dependencies:
+    yallist "^4.0.0"
+
 make-dir@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/make-dir/-/make-dir-2.1.0.tgz#5f0310e18b8be898cc07009295a30ae41e91e6f5"
@@ -2655,6 +2621,11 @@ make-dir@^2.1.0:
   dependencies:
     pify "^4.0.1"
     semver "^5.6.0"
+
+make-promises-safe@^5.1.0:
+  version "5.1.0"
+  resolved "https://registry.yarnpkg.com/make-promises-safe/-/make-promises-safe-5.1.0.tgz#dd9d311f555bcaa144f12e225b3d37785f0aa8f2"
+  integrity sha512-AfdZ49rtyhQR/6cqVKGoH7y4ql7XkS5HJI1lZm0/5N6CQosy1eYbBJ/qbhkKHzo17UH7M918Bysf6XB9f3kS1g==
 
 makeerror@1.0.x:
   version "1.0.11"
@@ -2737,11 +2708,6 @@ mime-types@^2.1.12, mime-types@~2.1.19:
   dependencies:
     mime-db "1.44.0"
 
-mimic-fn@^1.0.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
-  integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
-
 mimic-fn@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-2.1.0.tgz#7ed2c2ccccaf84d3ffcb7a69b57711fc2083401b"
@@ -2767,7 +2733,7 @@ mixin-deep@^1.2.0:
     for-in "^1.0.2"
     is-extendable "^1.0.1"
 
-mkdirp@^0.5.1, mkdirp@~0.5.0:
+mkdirp@^0.5.1:
   version "0.5.5"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.5.tgz#d91cefd62d1436ca0f41620e251288d420099def"
   integrity sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
@@ -2788,11 +2754,6 @@ ms@^2.1.1:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
-
-mute-stream@0.0.7:
-  version "0.0.7"
-  resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
-  integrity sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=
 
 mute-stream@0.0.8:
   version "0.0.8"
@@ -2831,26 +2792,24 @@ neo-async@^2.6.0:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
   integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
 
-neon-cli@^0.3.3:
-  version "0.3.3"
-  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.3.3.tgz#deb1c5a03a2fad996db5a6700ad283a8d24d7aab"
-  integrity sha512-P2kc9ZDp0fXfmHDx3YcQwX8gvZew8WroXG3YY6N2LZoYZNrnGUWIOYGQcck52Jmry+ka02xDtw+lCHpOuGoxRA==
+neon-cli@^0.8.2:
+  version "0.8.2"
+  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.8.2.tgz#5111b0e9d5d90273bdf85a9aa40a1a47a32df2ef"
+  integrity sha512-vYRBmiLiwPVeBvR9huCFXRAtdLYfsoSG3hgsXrcuyMSXk7yqpnZlgvOGGuxfhrRb/iNfcd0M0cEs0j22mDgZ+A==
   dependencies:
-    chalk "~2.1.0"
-    command-line-args "^4.0.2"
-    command-line-commands "^2.0.0"
-    command-line-usage "^4.0.0"
+    chalk "^4.1.0"
+    command-line-args "^5.1.1"
+    command-line-commands "^3.0.1"
+    command-line-usage "^6.1.0"
     git-config "0.0.7"
-    handlebars "^4.1.0"
-    inquirer "^3.0.6"
-    mkdirp "^0.5.1"
-    quickly-copy-file "^1.0.0"
-    rimraf "^2.6.1"
-    rsvp "^4.6.1"
-    semver "^5.1.0"
-    toml "^2.3.0"
-    ts-typed-json "^0.2.2"
-    validate-npm-package-license "^3.0.1"
+    handlebars "^4.7.6"
+    inquirer "^7.3.3"
+    make-promises-safe "^5.1.0"
+    rimraf "^3.0.2"
+    semver "^7.3.2"
+    toml "^3.0.0"
+    ts-typed-json "^0.3.2"
+    validate-npm-package-license "^3.0.4"
     validate-npm-package-name "^3.0.0"
 
 nice-try@^1.0.4:
@@ -2970,13 +2929,6 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
   integrity sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
   dependencies:
     wrappy "1"
-
-onetime@^2.0.0:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-2.0.1.tgz#067428230fd67443b2794b22bba528b6867962d4"
-  integrity sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
-  dependencies:
-    mimic-fn "^1.0.0"
 
 onetime@^5.1.0:
   version "5.1.0"
@@ -3180,13 +3132,6 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
-quickly-copy-file@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/quickly-copy-file/-/quickly-copy-file-1.0.0.tgz#9f8ff066230510ee7422b0121472b093a8690859"
-  integrity sha1-n4/wZiMFEO50IrASFHKwk6hpCFk=
-  dependencies:
-    mkdirp "~0.5.0"
-
 react-is@^16.8.4:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
@@ -3216,10 +3161,10 @@ realpath-native@^1.1.0:
   dependencies:
     util.promisify "^1.0.0"
 
-reduce-flatten@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-1.0.1.tgz#258c78efd153ddf93cb561237f61184f3696e327"
-  integrity sha1-JYx479FT3fk8tWEjf2EYTzaW4yc=
+reduce-flatten@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/reduce-flatten/-/reduce-flatten-2.0.0.tgz#734fd84e65f375d7ca4465c69798c25c9d10ae27"
+  integrity sha512-EJ4UNY/U1t2P/2k6oqotuX2Cc3T6nxJwsM0N0asT7dhrtH1ltUxDn4NalSYmPE2rCkVpcf/X6R0wDwcFpzhd4w==
 
 regex-not@^1.0.0, regex-not@^1.0.2:
   version "1.0.2"
@@ -3342,14 +3287,6 @@ resolve@^1.10.0, resolve@^1.3.2:
   dependencies:
     path-parse "^1.0.6"
 
-restore-cursor@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
-  integrity sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
-  dependencies:
-    onetime "^2.0.0"
-    signal-exit "^3.0.2"
-
 restore-cursor@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/restore-cursor/-/restore-cursor-3.1.0.tgz#39f67c54b3a7a58cea5236d95cf0034239631f7e"
@@ -3370,46 +3307,43 @@ rimraf@2.6.3:
   dependencies:
     glob "^7.1.3"
 
-rimraf@^2.5.4, rimraf@^2.6.1, rimraf@^2.6.3:
+rimraf@^2.5.4, rimraf@^2.6.3:
   version "2.7.1"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
   integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
   dependencies:
     glob "^7.1.3"
 
-rsvp@^3.5.0:
-  version "3.6.2"
-  resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-3.6.2.tgz#2e96491599a96cde1b515d5674a8f7a91452926a"
-  integrity sha512-OfWGQTb9vnwRjwtA2QwpG2ICclHC3pgXZO5xt8H2EfgDquO0qVdSb5T88L4qJVAEugbS56pAuV4XZM58UX8ulw==
+rimraf@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
+  integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+  dependencies:
+    glob "^7.1.3"
 
-rsvp@^4.6.1, rsvp@^4.8.4:
+rsvp@^4.8.4:
   version "4.8.5"
   resolved "https://registry.yarnpkg.com/rsvp/-/rsvp-4.8.5.tgz#c8f155311d167f68f21e168df71ec5b083113734"
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
-run-async@^2.2.0, run-async@^2.4.0:
+run-async@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.0.tgz#e59054a5b86876cfae07f431d18cbaddc594f1e8"
   integrity sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
   dependencies:
     is-promise "^2.1.0"
 
-rx-lite-aggregates@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz#753b87a89a11c95467c4ac1626c4efc4e05c67be"
-  integrity sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=
-  dependencies:
-    rx-lite "*"
-
-rx-lite@*, rx-lite@^4.0.8:
-  version "4.0.8"
-  resolved "https://registry.yarnpkg.com/rx-lite/-/rx-lite-4.0.8.tgz#0b1e11af8bc44836f04a6407e92da42467b79444"
-  integrity sha1-Cx4Rr4vESDbwSmQH6S2kJGe3lEQ=
-
 rxjs@^6.5.3:
   version "6.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
   integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
+  dependencies:
+    tslib "^1.9.0"
+
+rxjs@^6.6.0:
+  version "6.6.7"
+  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.7.tgz#90ac018acabf491bf65044235d5863c4dab804c9"
+  integrity sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==
   dependencies:
     tslib "^1.9.0"
 
@@ -3455,7 +3389,7 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.1.0, semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
@@ -3464,6 +3398,13 @@ semver@^6.0.0, semver@^6.1.2, semver@^6.2.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+
+semver@^7.3.2:
+  version "7.3.5"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.5.tgz#0b621c879348d8998e4b0e4be94b3f12e6018ef7"
+  integrity sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==
+  dependencies:
+    lru-cache "^6.0.0"
 
 set-blocking@^2.0.0:
   version "2.0.0"
@@ -3664,14 +3605,6 @@ string-length@^2.0.0:
     astral-regex "^1.0.0"
     strip-ansi "^4.0.0"
 
-string-width@^2.1.0:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-2.1.1.tgz#ab93f27a8dc13d28cac815c462143a6d9012ae9e"
-  integrity sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
-  dependencies:
-    is-fullwidth-code-point "^2.0.0"
-    strip-ansi "^4.0.0"
-
 string-width@^3.0.0, string-width@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-3.1.0.tgz#22767be21b62af1081574306f69ac51b62203961"
@@ -3760,13 +3693,6 @@ strip-json-comments@^3.0.1, strip-json-comments@^3.1.0:
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
   integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
 
-supports-color@^4.0.0:
-  version "4.5.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-4.5.0.tgz#be7a0de484dec5c5cddf8b3d59125044912f635b"
-  integrity sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=
-  dependencies:
-    has-flag "^2.0.0"
-
 supports-color@^5.3.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
@@ -3793,16 +3719,15 @@ symbol-tree@^3.2.2:
   resolved "https://registry.yarnpkg.com/symbol-tree/-/symbol-tree-3.2.4.tgz#430637d248ba77e078883951fb9aa0eed7c63fa2"
   integrity sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
 
-table-layout@^0.4.2:
-  version "0.4.5"
-  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-0.4.5.tgz#d906de6a25fa09c0c90d1d08ecd833ecedcb7378"
-  integrity sha512-zTvf0mcggrGeTe/2jJ6ECkJHAQPIYEwDoqsiqBjI24mvRmQbInK5jq33fyypaCBxX08hMkfmdOqj6haT33EqWw==
+table-layout@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/table-layout/-/table-layout-1.0.2.tgz#c4038a1853b0136d63365a734b6931cf4fad4a04"
+  integrity sha512-qd/R7n5rQTRFi+Zf2sk5XVVd9UQl6ZkduPFC3S7WEGJAmetDTjY3qPN50eSKzwuzEyQKy5TN2TiZdkIjos2L6A==
   dependencies:
-    array-back "^2.0.0"
+    array-back "^4.0.1"
     deep-extend "~0.6.0"
-    lodash.padend "^4.6.1"
-    typical "^2.6.1"
-    wordwrapjs "^3.0.0"
+    typical "^5.2.0"
+    wordwrapjs "^4.0.0"
 
 table@^5.2.3:
   version "5.4.6"
@@ -3828,14 +3753,6 @@ test-exclude@^5.2.3:
     minimatch "^3.0.4"
     read-pkg-up "^4.0.0"
     require-main-filename "^2.0.0"
-
-test-value@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/test-value/-/test-value-2.1.0.tgz#11da6ff670f3471a73b625ca4f3fdcf7bb748291"
-  integrity sha1-Edpv9nDzRxpztiXKTz/c97t0gpE=
-  dependencies:
-    array-back "^1.0.3"
-    typical "^2.6.0"
 
 text-table@^0.2.0:
   version "0.2.0"
@@ -3894,10 +3811,10 @@ to-regex@^3.0.1, to-regex@^3.0.2:
     regex-not "^1.0.2"
     safe-regex "^1.1.0"
 
-toml@^2.3.0:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/toml/-/toml-2.3.6.tgz#25b0866483a9722474895559088b436fd11f861b"
-  integrity sha512-gVweAectJU3ebq//Ferr2JUY4WKSDe5N+z0FvjDncLGyHmIDoxgY/2Ie4qfEIDm4IS7OA6Rmdm7pdEEdMcV/xQ==
+toml@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/toml/-/toml-3.0.0.tgz#342160f1af1904ec9d204d03a5d61222d762c5ee"
+  integrity sha512-y/mWCZinnvxjTKYhJ+pYxwD0mRLVvOtdS2Awbgxln6iEnt4rk0yBxeSBHkGJcPucRiG0e55mwWp+g/05rsrd6w==
 
 tough-cookie@^2.3.3, tough-cookie@^2.3.4, tough-cookie@~2.5.0:
   version "2.5.0"
@@ -3914,12 +3831,10 @@ tr46@^1.0.1:
   dependencies:
     punycode "^2.1.0"
 
-ts-typed-json@^0.2.2:
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/ts-typed-json/-/ts-typed-json-0.2.2.tgz#53184bee893e45991b73c8c463a38b59e27cd47e"
-  integrity sha1-UxhL7ok+RZkbc8jEY6OLWeJ81H4=
-  dependencies:
-    rsvp "^3.5.0"
+ts-typed-json@^0.3.2:
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/ts-typed-json/-/ts-typed-json-0.3.2.tgz#f4f20f45950bae0a383857f7b0a94187eca1b56a"
+  integrity sha512-Tdu3BWzaer7R5RvBIJcg9r8HrTZgpJmsX+1meXMJzYypbkj8NK2oJN0yvm4Dp/Iv6tzFa/L5jKRmEVTga6K3nA==
 
 tslib@^1.9.0:
   version "1.11.1"
@@ -3955,10 +3870,15 @@ type-fest@^0.8.1:
   resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.8.1.tgz#09e249ebde851d3b1e48d27c105444667f17b83d"
   integrity sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
 
-typical@^2.6.0, typical@^2.6.1:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/typical/-/typical-2.6.1.tgz#5c080e5d661cbbe38259d2e70a3c7253e873881d"
-  integrity sha1-XAgOXWYcu+OCWdLnCjxyU+hziB0=
+typical@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-4.0.0.tgz#cbeaff3b9d7ae1e2bbfaf5a4e6f11eccfde94fc4"
+  integrity sha512-VAH4IvQ7BDFYglMd7BPRDfLgxZZX4O4TFcRDA6EN5X7erNJJq+McIEp8np9aVtxrCJ6qx4GTYVfOWNjcqwZgRw==
+
+typical@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/typical/-/typical-5.2.0.tgz#4daaac4f2b5315460804f0acf6cb69c52bb93066"
+  integrity sha512-dvdQgNDNJo+8B2uBQoqdb11eUCE1JQXhvjC/CZtgvZseVd5TYMXnq0+vuUemXbd/Se29cTaUuPX3YIc2xgbvIg==
 
 uc.micro@^1.0.1, uc.micro@^1.0.5:
   version "1.0.6"
@@ -4032,7 +3952,7 @@ v8-compile-cache@^2.0.3:
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
   integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
 
-validate-npm-package-license@^3.0.1:
+validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/validate-npm-package-license/-/validate-npm-package-license-3.0.4.tgz#fc91f6b9c7ba15c857f4cb2c5defeec39d4f410a"
   integrity sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
@@ -4127,13 +4047,13 @@ wordwrap@^1.0.0:
   resolved "https://registry.yarnpkg.com/wordwrap/-/wordwrap-1.0.0.tgz#27584810891456a4171c8d0226441ade90cbcaeb"
   integrity sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=
 
-wordwrapjs@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-3.0.0.tgz#c94c372894cadc6feb1a66bff64e1d9af92c5d1e"
-  integrity sha512-mO8XtqyPvykVCsrwj5MlOVWvSnCdT+C+QVbm6blradR7JExAhbkZ7hZ9A+9NUtwzSqrlUo9a67ws0EiILrvRpw==
+wordwrapjs@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/wordwrapjs/-/wordwrapjs-4.0.1.tgz#d9790bccfb110a0fc7836b5ebce0937b37a8b98f"
+  integrity sha512-kKlNACbvHrkpIw6oPeYDSmdCTu2hdMHoyXLTcUKala++lx5Y+wjJ/e474Jqv5abnVmwxw08DiTuHmw69lJGksA==
   dependencies:
-    reduce-flatten "^1.0.1"
-    typical "^2.6.1"
+    reduce-flatten "^2.0.0"
+    typical "^5.2.0"
 
 wrap-ansi@^5.1.0:
   version "5.1.0"
@@ -4186,6 +4106,11 @@ y18n@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
   integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
 
 yargs-parser@^13.1.2:
   version "13.1.2"

--- a/seshat-node/yarn.lock
+++ b/seshat-node/yarn.lock
@@ -2,152 +2,177 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.8.3.tgz#33e25903d7481181534e12ec0a25f16b6fcf419e"
-  integrity sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.14.5.tgz#23b08d740e83f49c5e59945fbf1b43e80bbf4edb"
+  integrity sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==
   dependencies:
-    "@babel/highlight" "^7.8.3"
+    "@babel/highlight" "^7.14.5"
+
+"@babel/compat-data@^7.14.5":
+  version "7.14.7"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.14.7.tgz#7b047d7a3a89a67d2258dc61f604f098f1bc7e08"
+  integrity sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw==
 
 "@babel/core@^7.1.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.9.0.tgz#ac977b538b77e132ff706f3b8a4dbad09c03c56e"
-  integrity sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/core/-/core-7.14.6.tgz#e0814ec1a950032ff16c13a2721de39a8416fcab"
+  integrity sha512-gJnOEWSqTk96qG5BoIrl5bVtc23DCycmIePPYnamY9RboYdI4nFy5vAQMSl81O5K/W0sLDWfGysnOECC+KUUCA==
   dependencies:
-    "@babel/code-frame" "^7.8.3"
-    "@babel/generator" "^7.9.0"
-    "@babel/helper-module-transforms" "^7.9.0"
-    "@babel/helpers" "^7.9.0"
-    "@babel/parser" "^7.9.0"
-    "@babel/template" "^7.8.6"
-    "@babel/traverse" "^7.9.0"
-    "@babel/types" "^7.9.0"
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.14.5"
+    "@babel/helper-compilation-targets" "^7.14.5"
+    "@babel/helper-module-transforms" "^7.14.5"
+    "@babel/helpers" "^7.14.6"
+    "@babel/parser" "^7.14.6"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
     convert-source-map "^1.7.0"
     debug "^4.1.0"
-    gensync "^1.0.0-beta.1"
+    gensync "^1.0.0-beta.2"
     json5 "^2.1.2"
-    lodash "^4.17.13"
-    resolve "^1.3.2"
-    semver "^5.4.1"
+    semver "^6.3.0"
     source-map "^0.5.0"
 
-"@babel/generator@^7.4.0", "@babel/generator@^7.9.0", "@babel/generator@^7.9.5":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.9.5.tgz#27f0917741acc41e6eaaced6d68f96c3fa9afaf9"
-  integrity sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==
+"@babel/generator@^7.14.5", "@babel/generator@^7.4.0":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.14.5.tgz#848d7b9f031caca9d0cd0af01b063f226f52d785"
+  integrity sha512-y3rlP+/G25OIX3mYKKIOlQRcqj7YgrvHxOLbVmyLJ9bPmi5ttvUmpydVjcFjZphOktWuA7ovbx91ECloWTfjIA==
   dependencies:
-    "@babel/types" "^7.9.5"
+    "@babel/types" "^7.14.5"
     jsesc "^2.5.1"
-    lodash "^4.17.13"
     source-map "^0.5.0"
 
-"@babel/helper-function-name@^7.9.5":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz#2b53820d35275120e1874a82e5aabe1376920a5c"
-  integrity sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==
+"@babel/helper-compilation-targets@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz#7a99c5d0967911e972fe2c3411f7d5b498498ecf"
+  integrity sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==
   dependencies:
-    "@babel/helper-get-function-arity" "^7.8.3"
-    "@babel/template" "^7.8.3"
-    "@babel/types" "^7.9.5"
+    "@babel/compat-data" "^7.14.5"
+    "@babel/helper-validator-option" "^7.14.5"
+    browserslist "^4.16.6"
+    semver "^6.3.0"
 
-"@babel/helper-get-function-arity@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz#b894b947bd004381ce63ea1db9f08547e920abd5"
-  integrity sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==
+"@babel/helper-function-name@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz#89e2c474972f15d8e233b52ee8c480e2cfcd50c4"
+  integrity sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/helper-get-function-arity" "^7.14.5"
+    "@babel/template" "^7.14.5"
+    "@babel/types" "^7.14.5"
 
-"@babel/helper-member-expression-to-functions@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz#659b710498ea6c1d9907e0c73f206eee7dadc24c"
-  integrity sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==
+"@babel/helper-get-function-arity@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz#25fbfa579b0937eee1f3b805ece4ce398c431815"
+  integrity sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.14.5"
 
-"@babel/helper-module-imports@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
-  integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
+"@babel/helper-hoist-variables@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz#e0dd27c33a78e577d7c8884916a3e7ef1f7c7f8d"
+  integrity sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.14.5"
 
-"@babel/helper-module-transforms@^7.9.0":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz#43b34dfe15961918707d247327431388e9fe96e5"
-  integrity sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==
+"@babel/helper-member-expression-to-functions@^7.14.5":
+  version "7.14.7"
+  resolved "https://registry.yarnpkg.com/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz#97e56244beb94211fe277bd818e3a329c66f7970"
+  integrity sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==
   dependencies:
-    "@babel/helper-module-imports" "^7.8.3"
-    "@babel/helper-replace-supers" "^7.8.6"
-    "@babel/helper-simple-access" "^7.8.3"
-    "@babel/helper-split-export-declaration" "^7.8.3"
-    "@babel/template" "^7.8.6"
-    "@babel/types" "^7.9.0"
-    lodash "^4.17.13"
+    "@babel/types" "^7.14.5"
 
-"@babel/helper-optimise-call-expression@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz#7ed071813d09c75298ef4f208956006b6111ecb9"
-  integrity sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==
+"@babel/helper-module-imports@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz#6d1a44df6a38c957aa7c312da076429f11b422f3"
+  integrity sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-module-transforms@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-transforms/-/helper-module-transforms-7.14.5.tgz#7de42f10d789b423eb902ebd24031ca77cb1e10e"
+  integrity sha512-iXpX4KW8LVODuAieD7MzhNjmM6dzYY5tfRqT+R9HDXWl0jPn/djKmA+G9s/2C2T9zggw5tK1QNqZ70USfedOwA==
+  dependencies:
+    "@babel/helper-module-imports" "^7.14.5"
+    "@babel/helper-replace-supers" "^7.14.5"
+    "@babel/helper-simple-access" "^7.14.5"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/helper-validator-identifier" "^7.14.5"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
+
+"@babel/helper-optimise-call-expression@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz#f27395a8619e0665b3f0364cddb41c25d71b499c"
+  integrity sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==
+  dependencies:
+    "@babel/types" "^7.14.5"
 
 "@babel/helper-plugin-utils@^7.0.0", "@babel/helper-plugin-utils@^7.8.0":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz#9ea293be19babc0f52ff8ca88b34c3611b208670"
-  integrity sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz#5ac822ce97eec46741ab70a517971e443a70c5a9"
+  integrity sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ==
 
-"@babel/helper-replace-supers@^7.8.6":
-  version "7.8.6"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz#5ada744fd5ad73203bf1d67459a27dcba67effc8"
-  integrity sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==
+"@babel/helper-replace-supers@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz#0ecc0b03c41cd567b4024ea016134c28414abb94"
+  integrity sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==
   dependencies:
-    "@babel/helper-member-expression-to-functions" "^7.8.3"
-    "@babel/helper-optimise-call-expression" "^7.8.3"
-    "@babel/traverse" "^7.8.6"
-    "@babel/types" "^7.8.6"
+    "@babel/helper-member-expression-to-functions" "^7.14.5"
+    "@babel/helper-optimise-call-expression" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
 
-"@babel/helper-simple-access@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz#7f8109928b4dab4654076986af575231deb639ae"
-  integrity sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==
+"@babel/helper-simple-access@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-simple-access/-/helper-simple-access-7.14.5.tgz#66ea85cf53ba0b4e588ba77fc813f53abcaa41c4"
+  integrity sha512-nfBN9xvmCt6nrMZjfhkl7i0oTV3yxR4/FztsbOASyTvVcoYd0TRHh7eMLdlEcCqobydC0LAF3LtC92Iwxo0wyw==
   dependencies:
-    "@babel/template" "^7.8.3"
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.14.5"
 
-"@babel/helper-split-export-declaration@^7.8.3":
-  version "7.8.3"
-  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz#31a9f30070f91368a7182cf05f831781065fc7a9"
-  integrity sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==
+"@babel/helper-split-export-declaration@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz#22b23a54ef51c2b7605d851930c1976dd0bc693a"
+  integrity sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==
   dependencies:
-    "@babel/types" "^7.8.3"
+    "@babel/types" "^7.14.5"
 
-"@babel/helper-validator-identifier@^7.9.0", "@babel/helper-validator-identifier@^7.9.5":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz#90977a8e6fbf6b431a7dc31752eee233bf052d80"
-  integrity sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==
+"@babel/helper-validator-identifier@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.5.tgz#d0f0e277c512e0c938277faa85a3968c9a44c0e8"
+  integrity sha512-5lsetuxCLilmVGyiLEfoHBRX8UCFD+1m2x3Rj97WrW3V7H3u4RWRXA4evMjImCsin2J2YT0QaVDGf+z8ondbAg==
 
-"@babel/helpers@^7.9.0":
-  version "7.9.2"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.9.2.tgz#b42a81a811f1e7313b88cba8adc66b3d9ae6c09f"
-  integrity sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==
+"@babel/helper-validator-option@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz#6e72a1fff18d5dfcb878e1e62f1a021c4b72d5a3"
+  integrity sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow==
+
+"@babel/helpers@^7.14.6":
+  version "7.14.6"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.14.6.tgz#5b58306b95f1b47e2a0199434fa8658fa6c21635"
+  integrity sha512-yesp1ENQBiLI+iYHSJdoZKUtRpfTlL1grDIX9NRlAVppljLw/4tTyYupIB7uIYmC3stW/imAv8EqaKaS/ibmeA==
   dependencies:
-    "@babel/template" "^7.8.3"
-    "@babel/traverse" "^7.9.0"
-    "@babel/types" "^7.9.0"
+    "@babel/template" "^7.14.5"
+    "@babel/traverse" "^7.14.5"
+    "@babel/types" "^7.14.5"
 
-"@babel/highlight@^7.8.3":
-  version "7.9.0"
-  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.9.0.tgz#4e9b45ccb82b79607271b2979ad82c7b68163079"
-  integrity sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==
+"@babel/highlight@^7.14.5":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/highlight/-/highlight-7.14.5.tgz#6861a52f03966405001f6aa534a01a24d99e8cd9"
+  integrity sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.9.0"
+    "@babel/helper-validator-identifier" "^7.14.5"
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.1.0", "@babel/parser@^7.4.3", "@babel/parser@^7.8.6", "@babel/parser@^7.9.0", "@babel/parser@^7.9.4":
-  version "7.9.4"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.9.4.tgz#68a35e6b0319bbc014465be43828300113f2f2e8"
-  integrity sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==
+"@babel/parser@^7.1.0", "@babel/parser@^7.14.5", "@babel/parser@^7.14.6", "@babel/parser@^7.14.7", "@babel/parser@^7.4.3", "@babel/parser@^7.9.4":
+  version "7.14.7"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.14.7.tgz#6099720c8839ca865a2637e6c85852ead0bdb595"
+  integrity sha512-X67Z5y+VBJuHB/RjwECp8kSl5uYi0BvRbNeWqkaJCVh+LiTPl19WBUfG627psSgp9rSf6ojuXghQM3ha6qHHdA==
 
 "@babel/plugin-syntax-object-rest-spread@^7.0.0":
   version "7.8.3"
@@ -156,37 +181,36 @@
   dependencies:
     "@babel/helper-plugin-utils" "^7.8.0"
 
-"@babel/template@^7.4.0", "@babel/template@^7.8.3", "@babel/template@^7.8.6":
-  version "7.8.6"
-  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.8.6.tgz#86b22af15f828dfb086474f964dcc3e39c43ce2b"
-  integrity sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==
+"@babel/template@^7.14.5", "@babel/template@^7.4.0":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.14.5.tgz#a9bc9d8b33354ff6e55a9c60d1109200a68974f4"
+  integrity sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==
   dependencies:
-    "@babel/code-frame" "^7.8.3"
-    "@babel/parser" "^7.8.6"
-    "@babel/types" "^7.8.6"
+    "@babel/code-frame" "^7.14.5"
+    "@babel/parser" "^7.14.5"
+    "@babel/types" "^7.14.5"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.3", "@babel/traverse@^7.8.6", "@babel/traverse@^7.9.0":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.9.5.tgz#6e7c56b44e2ac7011a948c21e283ddd9d9db97a2"
-  integrity sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.14.5", "@babel/traverse@^7.4.3":
+  version "7.14.7"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.14.7.tgz#64007c9774cfdc3abd23b0780bc18a3ce3631753"
+  integrity sha512-9vDr5NzHu27wgwejuKL7kIOm4bwEtaPQ4Z6cpCmjSuaRqpH/7xc4qcGEscwMqlkwgcXl6MvqoAjZkQ24uSdIZQ==
   dependencies:
-    "@babel/code-frame" "^7.8.3"
-    "@babel/generator" "^7.9.5"
-    "@babel/helper-function-name" "^7.9.5"
-    "@babel/helper-split-export-declaration" "^7.8.3"
-    "@babel/parser" "^7.9.0"
-    "@babel/types" "^7.9.5"
+    "@babel/code-frame" "^7.14.5"
+    "@babel/generator" "^7.14.5"
+    "@babel/helper-function-name" "^7.14.5"
+    "@babel/helper-hoist-variables" "^7.14.5"
+    "@babel/helper-split-export-declaration" "^7.14.5"
+    "@babel/parser" "^7.14.7"
+    "@babel/types" "^7.14.5"
     debug "^4.1.0"
     globals "^11.1.0"
-    lodash "^4.17.13"
 
-"@babel/types@^7.0.0", "@babel/types@^7.3.0", "@babel/types@^7.4.0", "@babel/types@^7.8.3", "@babel/types@^7.8.6", "@babel/types@^7.9.0", "@babel/types@^7.9.5":
-  version "7.9.5"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.9.5.tgz#89231f82915a8a566a703b3b20133f73da6b9444"
-  integrity sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==
+"@babel/types@^7.0.0", "@babel/types@^7.14.5", "@babel/types@^7.3.0", "@babel/types@^7.4.0":
+  version "7.14.5"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.14.5.tgz#3bb997ba829a2104cedb20689c4a5b8121d383ff"
+  integrity sha512-M/NzBpEL95I5Hh4dwhin5JlE7EzO5PHMAuzjxss3tiOBD46KfQvVedN/3jEPZvdRvtsK2222XfdHogNIttFgcg==
   dependencies:
-    "@babel/helper-validator-identifier" "^7.9.5"
-    lodash "^4.17.13"
+    "@babel/helper-validator-identifier" "^7.14.5"
     to-fast-properties "^2.0.0"
 
 "@cnakazawa/watch@^1.0.3":
@@ -346,9 +370,9 @@
     "@types/yargs" "^13.0.0"
 
 "@types/babel__core@^7.1.0":
-  version "7.1.7"
-  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.7.tgz#1dacad8840364a57c98d0dd4855c6dd3752c6b89"
-  integrity sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==
+  version "7.1.14"
+  resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.14.tgz#faaeefc4185ec71c389f4501ee5ec84b170cc402"
+  integrity sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
@@ -357,36 +381,31 @@
     "@types/babel__traverse" "*"
 
 "@types/babel__generator@*":
-  version "7.6.1"
-  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.1.tgz#4901767b397e8711aeb99df8d396d7ba7b7f0e04"
-  integrity sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==
+  version "7.6.2"
+  resolved "https://registry.yarnpkg.com/@types/babel__generator/-/babel__generator-7.6.2.tgz#f3d71178e187858f7c45e30380f8f1b7415a12d8"
+  integrity sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==
   dependencies:
     "@babel/types" "^7.0.0"
 
 "@types/babel__template@*":
-  version "7.0.2"
-  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.0.2.tgz#4ff63d6b52eddac1de7b975a5223ed32ecea9307"
-  integrity sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==
+  version "7.4.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__template/-/babel__template-7.4.0.tgz#0c888dd70b3ee9eebb6e4f200e809da0076262be"
+  integrity sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==
   dependencies:
     "@babel/parser" "^7.1.0"
     "@babel/types" "^7.0.0"
 
 "@types/babel__traverse@*", "@types/babel__traverse@^7.0.6":
-  version "7.0.10"
-  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.0.10.tgz#d9a99f017317d9b3d1abc2ced45d3bca68df0daf"
-  integrity sha512-74fNdUGrWsgIB/V9kTO5FGHPWYY6Eqn+3Z7L6Hc4e/BxjYV7puvBqp5HwsVYYfLm6iURYBNCx4Ut37OF9yitCw==
+  version "7.14.0"
+  resolved "https://registry.yarnpkg.com/@types/babel__traverse/-/babel__traverse-7.14.0.tgz#a34277cf8acbd3185ea74129e1f100491eb1da7f"
+  integrity sha512-IilJZ1hJBUZwMOVDNTdflOOLzJB/ZtljYVa7k3gEZN/jqIJIPkWHC6dvbX+DD2CwZDHB9wAKzZPzzqMIkW37/w==
   dependencies:
     "@babel/types" "^7.3.0"
 
-"@types/color-name@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/color-name/-/color-name-1.1.1.tgz#1c1261bbeaa10a8055bbc5d8ab84b7b2afc846a0"
-  integrity sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0":
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.1.tgz#42995b446db9a48a11a07ec083499a860e9138ff"
-  integrity sha512-hRJD2ahnnpLgsj6KWMYSrmXkM3rm2Dl1qkx6IOFD5FnuNPXJIG5L0dhgKXCYTRMGzU4n0wImQ/xfmRc4POUFlg==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz#4ba8ddb720221f432e443bd5f9117fd22cfd4762"
+  integrity sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
 
 "@types/istanbul-lib-report@*":
   version "3.0.0"
@@ -396,9 +415,9 @@
     "@types/istanbul-lib-coverage" "*"
 
 "@types/istanbul-reports@^1.1.1":
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.1.tgz#7a8cbf6a406f36c8add871625b278eaf0b0d255a"
-  integrity sha512-UpYjBi8xefVChsCoBpKShdxTllC9pwISirfoZsUa2AAdQg/Jd2KQGtSbw+ya7GPo7x/wAPlH6JBhKhAsXUEZNA==
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz#e875cc689e47bce549ec81f3df5e6f6f11cfaeb2"
+  integrity sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==
   dependencies:
     "@types/istanbul-lib-coverage" "*"
     "@types/istanbul-lib-report" "*"
@@ -409,21 +428,21 @@
   integrity sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==
 
 "@types/yargs-parser@*":
-  version "15.0.0"
-  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-15.0.0.tgz#cb3f9f741869e20cce330ffbeb9271590483882d"
-  integrity sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw==
+  version "20.2.1"
+  resolved "https://registry.yarnpkg.com/@types/yargs-parser/-/yargs-parser-20.2.1.tgz#3b9ce2489919d9e4fea439b76916abc34b2df129"
+  integrity sha512-7tFImggNeNBVMsn0vLrpn1H1uPrUBdnARPTpZoitY37ZrdJREzf7I16tMrlK3hen349gr1NYh8CmZQa7CTG6Aw==
 
 "@types/yargs@^13.0.0":
-  version "13.0.8"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.8.tgz#a38c22def2f1c2068f8971acb3ea734eb3c64a99"
-  integrity sha512-XAvHLwG7UQ+8M4caKIH0ZozIOYay5fQkAgyIXegXT9jPtdIGdhga+sUEdAr1CiG46aB+c64xQEYyEzlwWVTNzA==
+  version "13.0.12"
+  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-13.0.12.tgz#d895a88c703b78af0465a9de88aa92c61430b092"
+  integrity sha512-qCxJE1qgz2y0hA4pIxjBR+PelCH0U5CK1XJXFwCNqfmliatKp47UCXXE9Dyk1OXBDLvsCF57TqQEJaeLfDYEOQ==
   dependencies:
     "@types/yargs-parser" "*"
 
 abab@^2.0.0:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.3.tgz#623e2075e02eb2d3f2475e49f99c91846467907a"
-  integrity sha512-tsFzPpcttalNjFBCFMqsKYQcWxxen1pgJR56by//QwvJc4/OUS3kPOOttx2tSIfjsylB0pYu7f5D3K1RCxUnUg==
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/abab/-/abab-2.0.5.tgz#c0b678fb32d60fc1219c784d6a826fe385aeb79a"
+  integrity sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
 
 acorn-globals@^4.1.0:
   version "4.3.4"
@@ -434,9 +453,9 @@ acorn-globals@^4.1.0:
     acorn-walk "^6.0.1"
 
 acorn-jsx@^5.2.0:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.2.0.tgz#4c66069173d6fdd68ed85239fc256226182b2ebe"
-  integrity sha512-HiUX/+K2YpkpJ+SzBffkM/AQ2YE03S0U1kjTLVpoJdhZMOWy8qvXVN9JdLqv2QsaQ6MPYQIuNmwD8zOiYUofLQ==
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/acorn-jsx/-/acorn-jsx-5.3.1.tgz#fc8661e11b7ac1539c47dbfea2e72b3af34d267b"
+  integrity sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
 
 acorn-walk@^6.0.1:
   version "6.2.0"
@@ -449,19 +468,19 @@ acorn@^5.5.3:
   integrity sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==
 
 acorn@^6.0.1:
-  version "6.4.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.1.tgz#531e58ba3f51b9dacb9a6646ca4debf5b14ca474"
-  integrity sha512-ZVA9k326Nwrj3Cj9jlh3wGFutC2ZornPNARZwsNYqQYgN0EsV2d53w5RN/co65Ohn4sUAUtb1rSUAOD6XN9idA==
+  version "6.4.2"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-6.4.2.tgz#35866fd710528e92de10cf06016498e47e39e1e6"
+  integrity sha512-XtGIhXwF8YM8bJhGxG5kXgjkEuNGLTkoYqVE+KMR+aspr4KGYmKYg7yUe3KghyQ9yheNwLnjmzh/7+gfDBmHCQ==
 
 acorn@^7.1.1:
-  version "7.1.1"
-  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.1.1.tgz#e35668de0b402f359de515c5482a1ab9f89a69bf"
-  integrity sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==
+  version "7.4.1"
+  resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
+  integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-ajv@^6.10.0, ajv@^6.10.2, ajv@^6.5.5:
-  version "6.12.2"
-  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.2.tgz#c629c5eced17baf314437918d2da88c99d5958cd"
-  integrity sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==
+ajv@^6.10.0, ajv@^6.10.2, ajv@^6.12.3:
+  version "6.12.6"
+  resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
+  integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
   dependencies:
     fast-deep-equal "^3.1.1"
     fast-json-stable-stringify "^2.0.0"
@@ -474,11 +493,11 @@ ansi-escapes@^3.0.0:
   integrity sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
 
 ansi-escapes@^4.2.1:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.1.tgz#a5c47cc43181f1f38ffd7076837700d395522a61"
-  integrity sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-4.3.2.tgz#6b2291d1db7d98b6521d5f1efa42d0f3a9feb65e"
+  integrity sha512-gKXj5ALrKWQLsYG9jlTRmR/xKluxHV+Z9QEwNIgCfM1/uwPMCuzVVnh5mwTd+OuBZcwSIMbqssNWRm1lE51QaQ==
   dependencies:
-    type-fest "^0.11.0"
+    type-fest "^0.21.3"
 
 ansi-regex@^3.0.0:
   version "3.0.0"
@@ -503,11 +522,10 @@ ansi-styles@^3.2.0, ansi-styles@^3.2.1:
     color-convert "^1.9.0"
 
 ansi-styles@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.2.1.tgz#90ae75c424d008d2624c5bf29ead3177ebfcf359"
-  integrity sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-4.3.0.tgz#edd803628ae71c04c85ae7a0906edad34b648937"
+  integrity sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
   dependencies:
-    "@types/color-name" "^1.1.1"
     color-convert "^2.0.1"
 
 anymatch@^2.0.0:
@@ -603,9 +621,9 @@ aws-sign2@~0.7.0:
   integrity sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
 
 aws4@^1.8.0:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.9.1.tgz#7e33d8f7d449b3f673cd72deb9abdc552dbe528e"
-  integrity sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
+  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
 
 babel-jest@^24.9.0:
   version "24.9.0"
@@ -646,9 +664,9 @@ babel-preset-jest@^24.9.0:
     babel-plugin-jest-hoist "^24.9.0"
 
 balanced-match@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.0.tgz#89b4d199ab2bee49de164ea02b89ce462d71b767"
-  integrity sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
+  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
 
 base@^0.11.1:
   version "0.11.2"
@@ -718,6 +736,17 @@ browser-resolve@^1.11.3:
   dependencies:
     resolve "1.1.7"
 
+browserslist@^4.16.6:
+  version "4.16.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.16.6.tgz#d7901277a5a88e554ed305b183ec9b0c08f66fa2"
+  integrity sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==
+  dependencies:
+    caniuse-lite "^1.0.30001219"
+    colorette "^1.2.2"
+    electron-to-chromium "^1.3.723"
+    escalade "^3.1.1"
+    node-releases "^1.1.71"
+
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -750,6 +779,14 @@ cache-base@^1.0.1:
     union-value "^1.0.0"
     unset-value "^1.0.0"
 
+call-bind@^1.0.0, call-bind@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.2.tgz#b1d4e89e688119c3c9a903ad30abb2f6a919be3c"
+  integrity sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.2"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -759,6 +796,11 @@ camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+
+caniuse-lite@^1.0.30001219:
+  version "1.0.30001242"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001242.tgz#04201627abcd60dc89211f22cbe2347306cda46b"
+  integrity sha512-KvNuZ/duufelMB3w2xtf9gEWCSxJwUgoxOx5b6ScLXC4kPc9xsczUVCPrQU26j5kOsHM4pSUL54tAZt5THQKug==
 
 capture-exit@^2.0.0:
   version "2.0.0"
@@ -772,12 +814,12 @@ caseless@~0.12.0:
   resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
   integrity sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
 
-catharsis@^0.8.11:
-  version "0.8.11"
-  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.8.11.tgz#d0eb3d2b82b7da7a3ce2efb1a7b00becc6643468"
-  integrity sha512-a+xUyMV7hD1BrDQA/3iPV7oc+6W26BgVJO05PGEoatMyIuPScQKsde6i3YorWX1qs+AZjnJ18NqdKoCtKiNh1g==
+catharsis@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/catharsis/-/catharsis-0.9.0.tgz#40382a168be0e6da308c277d3a2b3eb40c7d2121"
+  integrity sha512-prMTQVpcns/tzFgFVkVp6ak6RykZyWb3gu8ckUpd6YkTlacOd3DXGJjIpD4Q6zJirizvaiAjSSHlOsA+6sNh2A==
   dependencies:
-    lodash "^4.17.14"
+    lodash "^4.17.15"
 
 chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
   version "2.4.2"
@@ -787,14 +829,6 @@ chalk@^2.0.0, chalk@^2.0.1, chalk@^2.1.0, chalk@^2.4.2:
     ansi-styles "^3.2.1"
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
-
-chalk@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-3.0.0.tgz#3f73c2bf526591f574cc492c51e2456349f844e4"
-  integrity sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
-  dependencies:
-    ansi-styles "^4.1.0"
-    supports-color "^7.1.0"
 
 chalk@^4.1.0:
   version "4.1.1"
@@ -830,11 +864,6 @@ cli-cursor@^3.1.0:
   integrity sha512-I/zHAwsKf9FqGoXM4WWRACob9+SNukZTd94DWF57E4toouRulbCxcUh6RKUEOQlYTHJnzkPMySvPNaaSLNfLZw==
   dependencies:
     restore-cursor "^3.1.0"
-
-cli-width@^2.0.0:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.1.tgz#b0433d0b4e9c847ef18868a4ef16fd5fc8271c48"
-  integrity sha512-GRMWDxpOB6Dgk2E5Uo+3eEBvtOOlimMmpbFiKuLFnQzYDavtLFY3K5ona41jgN/WdRZtG7utuVSVTL4HbZHGkw==
 
 cli-width@^3.0.0:
   version "3.0.0"
@@ -887,6 +916,11 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
+colorette@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/colorette/-/colorette-1.2.2.tgz#cbcc79d5e99caea2dbf10eb3a26fd8b3e6acfa94"
+  integrity sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w==
+
 combined-stream@^1.0.6, combined-stream@~1.0.6:
   version "1.0.8"
   resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
@@ -921,11 +955,6 @@ command-line-usage@^6.1.0:
     table-layout "^1.0.1"
     typical "^5.2.0"
 
-commander@~2.20.3:
-  version "2.20.3"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
-  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
 component-emitter@^1.2.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/component-emitter/-/component-emitter-1.3.0.tgz#16e4070fba8ae29b679f2215853ee181ab2eabc0"
@@ -937,9 +966,9 @@ concat-map@0.0.1:
   integrity sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
 
 convert-source-map@^1.4.0, convert-source-map@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
-  integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.8.0.tgz#f3373c32d21b4d780dd8004514684fb791ca4369"
+  integrity sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==
   dependencies:
     safe-buffer "~5.1.1"
 
@@ -1000,11 +1029,11 @@ debug@^2.2.0, debug@^2.3.3:
     ms "2.0.0"
 
 debug@^4.0.1, debug@^4.1.0, debug@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/debug/-/debug-4.1.1.tgz#3b72260255109c6b589cee050f1d516139664791"
-  integrity sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==
+  version "4.3.2"
+  resolved "https://registry.yarnpkg.com/debug/-/debug-4.3.2.tgz#f0a49c18ac8779e31d4a0c6029dfb76873c7428b"
+  integrity sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==
   dependencies:
-    ms "^2.1.1"
+    ms "2.1.2"
 
 decamelize@^1.2.0:
   version "1.2.0"
@@ -1026,7 +1055,7 @@ deep-is@~0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.3.tgz#b369d6fb5dbc13eecf524f91b070feedc357cf34"
   integrity sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
 
-define-properties@^1.1.2, define-properties@^1.1.3:
+define-properties@^1.1.3:
   version "1.1.3"
   resolved "https://registry.yarnpkg.com/define-properties/-/define-properties-1.1.3.tgz#cf88da6cbee26fe6db7094f61d870cbd84cee9f1"
   integrity sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
@@ -1092,6 +1121,11 @@ ecc-jsbn@~0.1.1:
     jsbn "~0.1.0"
     safer-buffer "^2.1.0"
 
+electron-to-chromium@^1.3.723:
+  version "1.3.768"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.768.tgz#bbe47394f0073c947168589b7d19388518a7a9a9"
+  integrity sha512-I4UMZHhVSK2pwt8jOIxTi3GIuc41NkddtKT/hpuxp9GO5UWJgDKTBa4TACppbVAuKtKbMK6BhQZvT5tFF1bcNA==
+
 emoji-regex@^7.0.1:
   version "7.0.3"
   resolved "https://registry.yarnpkg.com/emoji-regex/-/emoji-regex-7.0.3.tgz#933a04052860c85e83c122479c4748a8e4c72156"
@@ -1110,9 +1144,9 @@ end-of-stream@^1.1.0:
     once "^1.4.0"
 
 entities@~2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.0.tgz#68d6084cab1b079767540d80e56a39b423e4abf4"
-  integrity sha512-D9f7V0JSRwIxlRI2mjMqufDrRDnx8p+eEOz7aUM9SuvF8gsBzra0/6tbjl1m8eQHrZlYj6PxqE00hZ1SAIKPLw==
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/entities/-/entities-2.0.3.tgz#5c487e5742ab93c15abb5da22759b8590ec03b7f"
+  integrity sha512-MyoZ0jgnLvB2X3Lg5HqpFmn1kybDiIfEQmKzTb5apr51Rb+T3KdmMiqa70T+bhGnyv7bQ6WMj2QMHpGMmlrUYQ==
 
 error-ex@^1.3.1:
   version "1.3.2"
@@ -1121,22 +1155,27 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.17.0-next.1, es-abstract@^1.17.2, es-abstract@^1.17.5:
-  version "1.17.5"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.17.5.tgz#d8c9d1d66c8981fb9200e2251d799eee92774ae9"
-  integrity sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==
+es-abstract@^1.18.0-next.2:
+  version "1.18.3"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.3.tgz#25c4c3380a27aa203c44b2b685bba94da31b63e0"
+  integrity sha512-nQIr12dxV7SSxE6r6f1l3DtAeEYdsGpps13dR0TwJg1S8gyp4ZPgy3FZcHBgbiQqnoqSTb+oC+kO4UQ0C/J8vw==
   dependencies:
+    call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
     function-bind "^1.1.1"
+    get-intrinsic "^1.1.1"
     has "^1.0.3"
-    has-symbols "^1.0.1"
-    is-callable "^1.1.5"
-    is-regex "^1.0.5"
-    object-inspect "^1.7.0"
+    has-symbols "^1.0.2"
+    is-callable "^1.2.3"
+    is-negative-zero "^2.0.1"
+    is-regex "^1.1.3"
+    is-string "^1.0.6"
+    object-inspect "^1.10.3"
     object-keys "^1.1.1"
-    object.assign "^4.1.0"
-    string.prototype.trimleft "^2.1.1"
-    string.prototype.trimright "^2.1.1"
+    object.assign "^4.1.2"
+    string.prototype.trimend "^1.0.4"
+    string.prototype.trimstart "^1.0.4"
+    unbox-primitive "^1.0.1"
 
 es-to-primitive@^1.2.1:
   version "1.2.1"
@@ -1146,6 +1185,11 @@ es-to-primitive@^1.2.1:
     is-callable "^1.1.4"
     is-date-object "^1.0.1"
     is-symbol "^1.0.2"
+
+escalade@^3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
+  integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
 
 escape-string-regexp@^1.0.5:
   version "1.0.5"
@@ -1158,9 +1202,9 @@ escape-string-regexp@^2.0.0:
   integrity sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
 
 escodegen@^1.9.1:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.1.tgz#ba01d0c8278b5e95a9a45350142026659027a457"
-  integrity sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==
+  version "1.14.3"
+  resolved "https://registry.yarnpkg.com/escodegen/-/escodegen-1.14.3.tgz#4e7b81fba61581dc97582ed78cab7f0e8d63f503"
+  integrity sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
   dependencies:
     esprima "^4.0.1"
     estraverse "^4.2.0"
@@ -1175,11 +1219,11 @@ eslint-config-google@^0.13.0:
   integrity sha512-ELgMdOIpn0CFdsQS+FuxO+Ttu4p+aLaXHv9wA9yVnzqlUGV7oN/eRRnJekk7TCur6Cu2FXX0fqfIXRBaM14lpQ==
 
 eslint-scope@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.0.0.tgz#e87c8887c73e8d1ec84f1ca591645c358bfc8fb9"
-  integrity sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
+  integrity sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
   dependencies:
-    esrecurse "^4.1.0"
+    esrecurse "^4.3.0"
     estraverse "^4.1.1"
 
 eslint-utils@^1.4.3:
@@ -1190,9 +1234,9 @@ eslint-utils@^1.4.3:
     eslint-visitor-keys "^1.1.0"
 
 eslint-visitor-keys@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.1.0.tgz#e2a82cea84ff246ad6fb57f9bde5b46621459ec2"
-  integrity sha512-8y9YjtM1JBJU/A9Kc+SbaOV4y29sSWckBwMHa+FGtVj5gN/sbnKDf6xJUl+8g7FAij9LVaP8C24DUiH/f/2Z9A==
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz#30ebd1ef7c2fdff01c3a4f151044af25fab0523e"
+  integrity sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
 
 eslint@^6.2.2:
   version "6.8.0"
@@ -1252,28 +1296,28 @@ esprima@^4.0.0, esprima@^4.0.1:
   integrity sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
 
 esquery@^1.0.1:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.3.1.tgz#b78b5828aa8e214e29fb74c4d5b752e1c033da57"
-  integrity sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/esquery/-/esquery-1.4.0.tgz#2148ffc38b82e8c7057dfed48425b3e61f0f24a5"
+  integrity sha512-cCDispWt5vHHtwMY2YrAQ4ibFkAL8RbH5YGBnZBc90MolvvfkkQcJro/aZiAQUlQ3qgrYS6D6v8Gc5G5CQsc9w==
   dependencies:
     estraverse "^5.1.0"
 
-esrecurse@^4.1.0:
-  version "4.2.1"
-  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.2.1.tgz#007a3b9fdbc2b3bb87e4879ea19c92fdbd3942cf"
-  integrity sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==
+esrecurse@^4.3.0:
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/esrecurse/-/esrecurse-4.3.0.tgz#7ad7964d679abb28bee72cec63758b1c5d2c9921"
+  integrity sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
   dependencies:
-    estraverse "^4.1.0"
+    estraverse "^5.2.0"
 
-estraverse@^4.1.0, estraverse@^4.1.1, estraverse@^4.2.0:
+estraverse@^4.1.1, estraverse@^4.2.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-4.3.0.tgz#398ad3f3c5a24948be7725e83d11a7de28cdbd1d"
   integrity sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
 
-estraverse@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.1.0.tgz#374309d39fd935ae500e7b92e8a6b4c720e59642"
-  integrity sha512-FyohXK+R0vE+y1nHLoBM7ZTyqRpqAlhdZHCWIWEviFLiGB8b04H6bQs8G+XTthacvT8VuwvteiP7RJSxMs8UEw==
+estraverse@^5.1.0, estraverse@^5.2.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/estraverse/-/estraverse-5.2.0.tgz#307df42547e6cc7324d3cf03c155d5cdb8c53880"
+  integrity sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
 
 esutils@^2.0.2:
   version "2.0.3"
@@ -1281,9 +1325,9 @@ esutils@^2.0.2:
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
 exec-sh@^0.3.2:
-  version "0.3.4"
-  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.4.tgz#3a018ceb526cc6f6df2bb504b2bfe8e3a4934ec5"
-  integrity sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
+  version "0.3.6"
+  resolved "https://registry.yarnpkg.com/exec-sh/-/exec-sh-0.3.6.tgz#ff264f9e325519a60cb5e273692943483cca63bc"
+  integrity sha512-nQn+hI3yp+oD0huYhKwvYI32+JFeq+XkNcD1GAo3Y/MjxsfVGmrrzrnzjWiNY6f+pUCP440fThsFh5gZrRAU/w==
 
 execa@^1.0.0:
   version "1.0.0"
@@ -1382,9 +1426,9 @@ extsprintf@^1.2.0:
   integrity sha1-4mifjzVvrWLMplo6kcXfX5VRaS8=
 
 fast-deep-equal@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz#545145077c501491e33b15ec408c294376e94ae4"
-  integrity sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
+  integrity sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
 
 fast-json-stable-stringify@^2.0.0:
   version "2.1.0"
@@ -1460,6 +1504,13 @@ flatted@^2.0.0:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-2.0.2.tgz#4575b21e2bcee7434aa9be662f4b7b5f9c2b5138"
   integrity sha512-r5wGx7YeOwNWNlCA0wQ86zKyDLMQr+/RB8xy74M4hTphfmjlijTSSXGuH8rnvKZnfT9i+75zmd8jcKdMR4O6jA==
 
+for-each@^0.3.3:
+  version "0.3.3"
+  resolved "https://registry.yarnpkg.com/for-each/-/for-each-0.3.3.tgz#69b447e88a0a5d32c3e7084f3f1710034b21376e"
+  integrity sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==
+  dependencies:
+    is-callable "^1.1.3"
+
 for-in@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"
@@ -1492,9 +1543,9 @@ fs.realpath@^1.0.0:
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
 fsevents@^1.2.7:
-  version "1.2.12"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.12.tgz#db7e0d8ec3b0b45724fd4d83d43554a8f1f0de5c"
-  integrity sha512-Ggd/Ktt7E7I8pxZRbGIs7vwqAPscSESMrCSkx2FtWeqmheJgCo2R74fTsZFCifr0VTPwqRpPv17+6b8Zp7th0Q==
+  version "1.2.13"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
+  integrity sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==
   dependencies:
     bindings "^1.5.0"
     nan "^2.12.1"
@@ -1509,15 +1560,24 @@ functional-red-black-tree@^1.0.1:
   resolved "https://registry.yarnpkg.com/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz#1b0ab3bd553b2a0d6399d29c0e3ea0b252078327"
   integrity sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
 
-gensync@^1.0.0-beta.1:
-  version "1.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.1.tgz#58f4361ff987e5ff6e1e7a210827aa371eaac269"
-  integrity sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==
+gensync@^1.0.0-beta.2:
+  version "1.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/gensync/-/gensync-1.0.0-beta.2.tgz#32a6ee76c3d7f52d46b2b1ae5d93fea8580a25e0"
+  integrity sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
 
 get-caller-file@^2.0.1:
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+
+get-intrinsic@^1.0.2, get-intrinsic@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.1.1.tgz#15f59f376f855c446963948f0d24cd3637b4abc6"
+  integrity sha512-kWZrnVM42QCiEA2Ig1bG8zjoIMOgxWwYCEeNdwY6Tv/cOSeGpcoX4pXHfKUxNKVoArnrEr2e9srnAxxGIraS9Q==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 get-stream@^4.0.0:
   version "4.1.0"
@@ -1546,16 +1606,16 @@ git-config@0.0.7:
     iniparser "~1.0.5"
 
 glob-parent@^5.0.0:
-  version "5.1.1"
-  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.1.tgz#b6c1ef417c4e5663ea498f1c45afac6916bbc229"
-  integrity sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
+  integrity sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==
   dependencies:
     is-glob "^4.0.1"
 
 glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
-  version "7.1.6"
-  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
-  integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+  version "7.1.7"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.7.tgz#3b193e9233f01d42d0b3f78294bbeeb418f94a90"
+  integrity sha512-OvD9ENzPLbegENnYP5UUfJIirTg4+XwMWGaQfQTY0JenxNvvIKP3U3/tAQSPIu/lHxXYSZmpXlUHeqAIdKzBLQ==
   dependencies:
     fs.realpath "^1.0.0"
     inflight "^1.0.4"
@@ -1577,9 +1637,9 @@ globals@^12.1.0:
     type-fest "^0.8.1"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.9:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.3.tgz#4a12ff1b60376ef09862c2093edd908328be8423"
-  integrity sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.6.tgz#ff040b2b0853b23c3d31027523706f1885d76bee"
+  integrity sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==
 
 growly@^1.3.0:
   version "1.3.0"
@@ -1604,12 +1664,17 @@ har-schema@^2.0.0:
   integrity sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
 
 har-validator@~5.1.3:
-  version "5.1.3"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.3.tgz#1ef89ebd3e4996557675eed9893110dc350fa080"
-  integrity sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==
+  version "5.1.5"
+  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
+  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
   dependencies:
-    ajv "^6.5.5"
+    ajv "^6.12.3"
     har-schema "^2.0.0"
+
+has-bigints@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.1.tgz#64fe6acb020673e3b78db035a5af69aa9d07b113"
+  integrity sha512-LSBS2LjbNBTf6287JEbEzvJgftkF5qFkmCo9hDRpAzKhUOlJ+hx8dd4USs00SgsUNwc4617J9ki5YtEClM2ffA==
 
 has-flag@^3.0.0:
   version "3.0.0"
@@ -1621,10 +1686,10 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
-has-symbols@^1.0.0, has-symbols@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.1.tgz#9f5214758a44196c406d9bd76cebf81ec2dd31e8"
-  integrity sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+has-symbols@^1.0.1, has-symbols@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.2.tgz#165d3070c00309752a1236a479331e3ac56f1423"
+  integrity sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==
 
 has-value@^0.3.1:
   version "0.3.1"
@@ -1665,9 +1730,9 @@ has@^1.0.3:
     function-bind "^1.1.1"
 
 hosted-git-info@^2.1.4:
-  version "2.8.8"
-  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.8.tgz#7539bd4bc1e0e0a895815a2e0262420b12858488"
-  integrity sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+  version "2.8.9"
+  resolved "https://registry.yarnpkg.com/hosted-git-info/-/hosted-git-info-2.8.9.tgz#dffc0bf9a21c02209090f2aa69429e1414daf3f9"
+  integrity sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==
 
 html-encoding-sniffer@^1.0.2:
   version "1.0.2"
@@ -1703,9 +1768,9 @@ ignore@^4.0.6:
   integrity sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
 
 import-fresh@^3.0.0:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
-  integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
+  version "3.3.0"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.3.0.tgz#37162c25fcb9ebaa2e6e53d5b4d88ce17d9e0c2b"
+  integrity sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -1741,26 +1806,7 @@ iniparser@~1.0.5:
   resolved "https://registry.yarnpkg.com/iniparser/-/iniparser-1.0.5.tgz#836d6befe6dfbfcee0bccf1cf9f2acc7027f783d"
   integrity sha1-g21r7+bfv87gvM8c+fKsxwJ/eD0=
 
-inquirer@^7.0.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.1.0.tgz#1298a01859883e17c7264b82870ae1034f92dd29"
-  integrity sha512-5fJMWEmikSYu0nv/flMc475MhGbB7TSPd/2IpFV4I4rMklboCH2rQjYY5kKiYGHqUF9gvaambupcJFFG9dvReg==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^3.0.0"
-    cli-cursor "^3.1.0"
-    cli-width "^2.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.15"
-    mute-stream "0.0.8"
-    run-async "^2.4.0"
-    rxjs "^6.5.3"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-    through "^2.3.6"
-
-inquirer@^7.3.3:
+inquirer@^7.0.0, inquirer@^7.3.3:
   version "7.3.3"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-7.3.3.tgz#04d176b2af04afc157a83fd7c100e98ee0aad003"
   integrity sha512-JG3eIAj5V9CwcGvuOmoo6LB9kbAYT8HXffUl6memuszlwDC/qvFAJw49XJ5NROSFNPxp3iQg1GqkFhaY/CR0IA==
@@ -1805,15 +1851,27 @@ is-arrayish@^0.2.1:
   resolved "https://registry.yarnpkg.com/is-arrayish/-/is-arrayish-0.2.1.tgz#77c99840527aa8ecb1a8ba697b80645a7a926a9d"
   integrity sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
 
+is-bigint@^1.0.1:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/is-bigint/-/is-bigint-1.0.2.tgz#ffb381442503235ad245ea89e45b3dbff040ee5a"
+  integrity sha512-0JV5+SOCQkIdzjBK9buARcV804Ddu7A0Qet6sHi3FimE9ne6m4BGQZfRn+NZiXbBk4F4XmHfDZIipLj9pX8dSA==
+
+is-boolean-object@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/is-boolean-object/-/is-boolean-object-1.1.1.tgz#3c0878f035cb821228d350d2e1e36719716a3de8"
+  integrity sha512-bXdQWkECBUIAcCkeH1unwJLIpZYaa5VvuygSyS/c2lf719mTKZDU5UdDRlpd01UjADgmW8RfqaP+mRaVPdr/Ng==
+  dependencies:
+    call-bind "^1.0.2"
+
 is-buffer@^1.1.5:
   version "1.1.6"
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-callable@^1.1.4, is-callable@^1.1.5:
-  version "1.1.5"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.1.5.tgz#f7e46b596890456db74e7f6e976cb3273d06faab"
-  integrity sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==
+is-callable@^1.1.3, is-callable@^1.1.4, is-callable@^1.2.3:
+  version "1.2.3"
+  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.3.tgz#8b1e0500b73a1d76c70487636f368e519de8db8e"
+  integrity sha512-J1DcMe8UYTBSrKezuIUTUwjXsho29693unXM2YhJUTR2txK/eG47bvNa/wipPFmZFgr/N6f1GA66dv0mEyTIyQ==
 
 is-ci@^2.0.0:
   version "2.0.0"
@@ -1821,6 +1879,13 @@ is-ci@^2.0.0:
   integrity sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
   dependencies:
     ci-info "^2.0.0"
+
+is-core-module@^2.2.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.4.0.tgz#8e9fc8e15027b011418026e98f0e6f4d86305cc1"
+  integrity sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==
+  dependencies:
+    has "^1.0.3"
 
 is-data-descriptor@^0.1.4:
   version "0.1.4"
@@ -1837,9 +1902,9 @@ is-data-descriptor@^1.0.0:
     kind-of "^6.0.0"
 
 is-date-object@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
-  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.4.tgz#550cfcc03afada05eea3dd30981c7b09551f73e5"
+  integrity sha512-/b4ZVsG7Z5XVtIxs/h9W8nvfLgSAyKYdtGWQLbqy6jA1icmgjf8WCoTKgeS4wy5tYaPePouzFMANbnj94c2Z+A==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -1898,6 +1963,16 @@ is-glob@^4.0.0, is-glob@^4.0.1:
   dependencies:
     is-extglob "^2.1.1"
 
+is-negative-zero@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.1.tgz#3de746c18dda2319241a53675908d8f766f11c24"
+  integrity sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+
+is-number-object@^1.0.4:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/is-number-object/-/is-number-object-1.0.5.tgz#6edfaeed7950cff19afedce9fbfca9ee6dd289eb"
+  integrity sha512-RU0lI/n95pMoUKu9v1BZP5MBcZuNSVJkMkAG2dJqC4z2GlkGUNeH68SuHuBKBD/XFe+LHZ+f9BKkLET60Niedw==
+
 is-number@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-3.0.0.tgz#24fd6201a4782cf50561c810276afc7d12d71195"
@@ -1912,29 +1987,30 @@ is-plain-object@^2.0.3, is-plain-object@^2.0.4:
   dependencies:
     isobject "^3.0.1"
 
-is-promise@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.1.0.tgz#79a2a9ece7f096e80f36d2b2f3bc16c1ff4bf3fa"
-  integrity sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=
-
-is-regex@^1.0.5:
-  version "1.0.5"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.0.5.tgz#39d589a358bf18967f726967120b8fc1aed74eae"
-  integrity sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==
+is-regex@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.3.tgz#d029f9aff6448b93ebbe3f33dac71511fdcbef9f"
+  integrity sha512-qSVXFz28HM7y+IWX6vLCsexdlvzT1PJNFSBuaQLQ5o0IEw8UDYW6/2+eCMVyIsbM8CNLX2a/QWmSpyxYEHY7CQ==
   dependencies:
-    has "^1.0.3"
+    call-bind "^1.0.2"
+    has-symbols "^1.0.2"
 
 is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
 
-is-symbol@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
-  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
+is-string@^1.0.5, is-string@^1.0.6:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/is-string/-/is-string-1.0.6.tgz#3fe5d5992fb0d93404f32584d4b0179a71b54a5f"
+  integrity sha512-2gdzbKUuqtQ3lYNrUTQYoClPhm7oQu4UdpSZMp1/DGgkHBT8E2Z1l0yMdb6D4zNAxwDiMv8MdulKROJGNl0Q0w==
+
+is-symbol@^1.0.2, is-symbol@^1.0.3:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.4.tgz#a6dac93b635b063ca6872236de88910a57af139c"
+  integrity sha512-C/CPBqKWnvdcxqIARxyOh4v1UUEOCHpgDa0WYgpKDFMszcrPcffg5uhwSgPCLD2WWxmq6isisz87tzT01tuGhg==
   dependencies:
-    has-symbols "^1.0.1"
+    has-symbols "^1.0.2"
 
 is-typedarray@~1.0.0:
   version "1.0.0"
@@ -2211,9 +2287,9 @@ jest-mock@^24.9.0:
     "@jest/types" "^24.9.0"
 
 jest-pnp-resolver@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.1.tgz#ecdae604c077a7fbc70defb6d517c3c1c898923a"
-  integrity sha512-pgFw2tm54fzgYvc/OHrnysABEObZCUNFnhjoRjaVOCN8NYc032/gVjPaHD4Aq6ApkSieWtfKAFQtmDKAmhupnQ==
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz#b704ac0ae028a89108a4d040b3f919dfddc8e33c"
+  integrity sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
 
 jest-regex-util@^24.3.0, jest-regex-util@^24.9.0:
   version "24.9.0"
@@ -2383,9 +2459,9 @@ jest@^24.9.0:
   integrity sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
 
 js-yaml@^3.13.1:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.13.1.tgz#aff151b30bfdfa8e49e05da22e7415e9dfa37847"
-  integrity sha512-YfbcO7jXDdyj0DGxYVSlSeQNHbD7XPWvrVWeVUujrQEoZzWJIRrCPoyk6kL6IAjAG2IolMK4T0hNUe0HOUs5Jw==
+  version "3.14.1"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
+  integrity sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
   dependencies:
     argparse "^1.0.7"
     esprima "^4.0.0"
@@ -2403,24 +2479,24 @@ jsbn@~0.1.0:
   integrity sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
 
 jsdoc@^3.6.3:
-  version "3.6.4"
-  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.6.4.tgz#246b2832a0ea8b37a441b61745509cfe29e174b6"
-  integrity sha512-3G9d37VHv7MFdheviDCjUfQoIjdv4TC5zTTf5G9VODLtOnVS6La1eoYBDlbWfsRT3/Xo+j2MIqki2EV12BZfwA==
+  version "3.6.7"
+  resolved "https://registry.yarnpkg.com/jsdoc/-/jsdoc-3.6.7.tgz#00431e376bed7f9de4716c6f15caa80e64492b89"
+  integrity sha512-sxKt7h0vzCd+3Y81Ey2qinupL6DpRSZJclS04ugHDNmRUXGzqicMJ6iwayhSA0S0DwwX30c5ozyUthr1QKF6uw==
   dependencies:
     "@babel/parser" "^7.9.4"
     bluebird "^3.7.2"
-    catharsis "^0.8.11"
+    catharsis "^0.9.0"
     escape-string-regexp "^2.0.0"
     js2xmlparser "^4.0.1"
     klaw "^3.0.0"
     markdown-it "^10.0.0"
     markdown-it-anchor "^5.2.7"
-    marked "^0.8.2"
+    marked "^2.0.3"
     mkdirp "^1.0.4"
     requizzle "^0.2.3"
     strip-json-comments "^3.1.0"
     taffydb "2.6.2"
-    underscore "~1.10.2"
+    underscore "~1.13.1"
 
 jsdom@^11.5.1:
   version "11.12.0"
@@ -2485,9 +2561,9 @@ json-stringify-safe@~5.0.1:
   integrity sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
 
 json5@^2.1.2:
-  version "2.1.3"
-  resolved "https://registry.yarnpkg.com/json5/-/json5-2.1.3.tgz#c9b0f7fa9233bfe5807fe66fcf3a5617ed597d43"
-  integrity sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.0.tgz#2dfefe720c6ba525d9ebd909950f0515316c89a3"
+  integrity sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==
   dependencies:
     minimist "^1.2.5"
 
@@ -2590,12 +2666,7 @@ lodash.sortby@^4.7.0:
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
   integrity sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
 
-lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15:
-  version "4.17.19"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.19.tgz#e48ddedbe30b3321783c5b4301fbd353bc1e4a4b"
-  integrity sha512-JNvd8XER9GQX0v2qJgsaN/mzFCNA5BRe/j8JN9d+tWyGLSodKQHKFicdwNYzWwI3wjRnaKPsGj1XkBjx/F96DQ==
-
-lodash@^4.17.19:
+lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -2647,9 +2718,9 @@ map-visit@^1.0.0:
     object-visit "^1.0.0"
 
 markdown-it-anchor@^5.2.7:
-  version "5.2.7"
-  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.2.7.tgz#ec740f6bd03258a582cd0c65b9644b9f9852e5a3"
-  integrity sha512-REFmIaSS6szaD1bye80DMbp7ePwsPNvLTR5HunsUcZ0SG0rWJQ+Pz24R4UlTKtjKBPhxo0v0tOBDYjZQQknW8Q==
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/markdown-it-anchor/-/markdown-it-anchor-5.3.0.tgz#d549acd64856a8ecd1bea58365ef385effbac744"
+  integrity sha512-/V1MnLL/rgJ3jkMWo84UR+K+jF1cxNG1a+KwqeXqTIJ+jtA8aWSHuigx8lTzauiIjBDbwF3NcWQMotd0Dm39jA==
 
 markdown-it@^10.0.0:
   version "10.0.0"
@@ -2662,10 +2733,10 @@ markdown-it@^10.0.0:
     mdurl "^1.0.1"
     uc.micro "^1.0.5"
 
-marked@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/marked/-/marked-0.8.2.tgz#4faad28d26ede351a7a1aaa5fec67915c869e355"
-  integrity sha512-EGwzEeCcLniFX51DhTpmTom+dSA/MG/OBUDjnWtHbEnjAH180VzUeAw+oE4+Zv+CoYBWyRlYOTR0N8SO9R1PVw==
+marked@^2.0.3:
+  version "2.1.3"
+  resolved "https://registry.yarnpkg.com/marked/-/marked-2.1.3.tgz#bd017cef6431724fd4b27e0657f5ceb14bff3753"
+  integrity sha512-/Q+7MGzaETqifOMWYEA7HVMaZb4XbcRfaOzcSsHZEith83KGlvaSG33u0SKu89Mj5h+T8V2hM+8O45Qc5XTgwA==
 
 mdurl@^1.0.1:
   version "1.0.1"
@@ -2696,17 +2767,17 @@ micromatch@^3.1.10, micromatch@^3.1.4:
     snapdragon "^0.8.1"
     to-regex "^3.0.2"
 
-mime-db@1.44.0:
-  version "1.44.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.44.0.tgz#fa11c5eb0aca1334b4233cb4d52f10c5a6272f92"
-  integrity sha512-/NOTfLrsPBVeH7YtFPgsVWveuL+4SjjYxaQ1xtM1KMFj7HdxlBlxeyNLzhyJVx7r4rZGJAZ/6lkKCitSc/Nmpg==
+mime-db@1.48.0:
+  version "1.48.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.48.0.tgz#e35b31045dd7eada3aaad537ed88a33afbef2d1d"
+  integrity sha512-FM3QwxV+TnZYQ2aRqhlKBMHxk10lTbMt3bBkMAp54ddrNeVSfcQYOOKuGuy3Ddrm38I04If834fOUSq1yzslJQ==
 
 mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.27"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.27.tgz#47949f98e279ea53119f5722e0f34e529bec009f"
-  integrity sha512-JIhqnCasI9yD+SsmkquHBxTSEuZdQX5BuQnS2Vc7puQQQ+8yiP5AY5uWhpdv4YL4VM5c6iliiYWPgJ/nJQLp7w==
+  version "2.1.31"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.31.tgz#a00d76b74317c61f9c2db2218b8e9f8e9c5c9e6b"
+  integrity sha512-XGZnNzm3QvgKxa8dpzyhFTHmpP3l5YNusmne07VUOXxou9CqUqYa/HBy124RqtVh/O2pECas/MOcsDgpilPOPg==
   dependencies:
-    mime-db "1.44.0"
+    mime-db "1.48.0"
 
 mimic-fn@^2.1.0:
   version "2.1.0"
@@ -2750,7 +2821,7 @@ ms@2.0.0:
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
   integrity sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
 
-ms@^2.1.1:
+ms@2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.1.2.tgz#d09d1f357b443f493382a8eb3ccd183872ae6009"
   integrity sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
@@ -2761,9 +2832,9 @@ mute-stream@0.0.8:
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
 nan@^2.12.1:
-  version "2.14.1"
-  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.1.tgz#d7be34dfa3105b91494c3147089315eff8874b01"
-  integrity sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==
+  version "2.14.2"
+  resolved "https://registry.yarnpkg.com/nan/-/nan-2.14.2.tgz#f5376400695168f4cc694ac9393d0c9585eeea19"
+  integrity sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==
 
 nanomatch@^1.2.9:
   version "1.2.13"
@@ -2788,14 +2859,14 @@ natural-compare@^1.4.0:
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
 
 neo-async@^2.6.0:
-  version "2.6.1"
-  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.1.tgz#ac27ada66167fa8849a6addd837f6b189ad2081c"
-  integrity sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
+  integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
 neon-cli@^0.8.2:
-  version "0.8.2"
-  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.8.2.tgz#5111b0e9d5d90273bdf85a9aa40a1a47a32df2ef"
-  integrity sha512-vYRBmiLiwPVeBvR9huCFXRAtdLYfsoSG3hgsXrcuyMSXk7yqpnZlgvOGGuxfhrRb/iNfcd0M0cEs0j22mDgZ+A==
+  version "0.8.3"
+  resolved "https://registry.yarnpkg.com/neon-cli/-/neon-cli-0.8.3.tgz#dea3a00021a07b9ef05e73464e45c94a2bf0fd3a"
+  integrity sha512-I44MB8PD0AEyFr/b5icR4sX1tsjdkb2T2uWEStG4Uf5C/jzalZPn7eazbQrW6KDyXNd8bc+LVuOr1v6CGTa1KQ==
   dependencies:
     chalk "^4.1.0"
     command-line-args "^5.1.1"
@@ -2828,15 +2899,20 @@ node-modules-regexp@^1.0.0:
   integrity sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
 
 node-notifier@^5.4.2:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.4.3.tgz#cb72daf94c93904098e28b9c590fd866e464bd50"
-  integrity sha512-M4UBGcs4jeOK9CjTsYwkvH6/MzuUmGCyTW+kCY7uO+1ZVr0+FHGdPdIf5CCLqAaxnRrWidyoQlNkMIIVwbKB8Q==
+  version "5.4.5"
+  resolved "https://registry.yarnpkg.com/node-notifier/-/node-notifier-5.4.5.tgz#0cbc1a2b0f658493b4025775a13ad938e96091ef"
+  integrity sha512-tVbHs7DyTLtzOiN78izLA85zRqB9NvEXkAf014Vx3jtSvn/xBl6bR8ZYifj+dFcFrKI21huSQgJZ6ZtL3B4HfQ==
   dependencies:
     growly "^1.3.0"
     is-wsl "^1.1.0"
     semver "^5.5.0"
     shellwords "^0.1.1"
     which "^1.3.0"
+
+node-releases@^1.1.71:
+  version "1.1.73"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.73.tgz#dd4e81ddd5277ff846b80b52bb40c49edf7a7b20"
+  integrity sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg==
 
 normalize-package-data@^2.3.2:
   version "2.5.0"
@@ -2881,12 +2957,12 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.7.0:
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.7.0.tgz#f4f6bd181ad77f006b5ece60bd0b6f398ff74a67"
-  integrity sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==
+object-inspect@^1.10.3:
+  version "1.10.3"
+  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.10.3.tgz#c2aa7d2d09f50c99375704f7a0adf24c5782d369"
+  integrity sha512-e5mCJlSH7poANfC8z8S9s9S2IN5/4Zb3aZ33f5s8YqoazCFzNLloLU8r5VCG+G7WoqLvAAZoVMcy3tp/3X0Plw==
 
-object-keys@^1.0.11, object-keys@^1.0.12, object-keys@^1.1.1:
+object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
   integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
@@ -2898,23 +2974,24 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.0.tgz#968bf1100d7956bb3ca086f006f846b3bc4008da"
-  integrity sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==
+object.assign@^4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
   dependencies:
-    define-properties "^1.1.2"
-    function-bind "^1.1.1"
-    has-symbols "^1.0.0"
-    object-keys "^1.0.11"
-
-object.getownpropertydescriptors@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz#369bf1f9592d8ab89d712dced5cb81c7c5352649"
-  integrity sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==
-  dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.0-next.1"
+    has-symbols "^1.0.1"
+    object-keys "^1.1.1"
+
+object.getownpropertydescriptors@^2.1.1:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.2.tgz#1bd63aeacf0d5d2d2f31b5e393b03a7c601a23f7"
+  integrity sha512-WtxeKSzfBjlzL+F9b7M7hewDzMwy+C8NRssHd1YrNlzHzIDrXcXiNOMrezdAEM4UXixgV+vvnyBeN7Rygl2ttQ==
+  dependencies:
+    call-bind "^1.0.2"
+    define-properties "^1.1.3"
+    es-abstract "^1.18.0-next.2"
 
 object.pick@^1.3.0:
   version "1.3.0"
@@ -2931,9 +3008,9 @@ once@^1.3.0, once@^1.3.1, once@^1.4.0:
     wrappy "1"
 
 onetime@^5.1.0:
-  version "5.1.0"
-  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.0.tgz#fff0f3c91617fe62bb50189636e99ac8a6df7be5"
-  integrity sha512-5NcSkPHhwTVFIQN+TUqXoS5+dlElHXdpAWu9I0HP20YOtIi+aZ0Ct82jdlILDxjLEAWwvm+qj1m6aEtsDVmm6Q==
+  version "5.1.2"
+  resolved "https://registry.yarnpkg.com/onetime/-/onetime-5.1.2.tgz#d0e96ebb56b07476df1dd9c4806e5237985ca45e"
+  integrity sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
   dependencies:
     mimic-fn "^2.1.0"
 
@@ -3031,9 +3108,9 @@ path-key@^2.0.0, path-key@^2.0.1:
   integrity sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
 
 path-parse@^1.0.6:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
-  integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.7.tgz#fbc114b60ca42b30d9daf5858e4bd68bbedb6735"
+  integrity sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==
 
 path-type@^3.0.0:
   version "3.0.0"
@@ -3102,12 +3179,12 @@ progress@^2.0.0:
   integrity sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
 
 prompts@^2.0.1:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.3.2.tgz#480572d89ecf39566d2bd3fe2c9fccb7c4c0b068"
-  integrity sha512-Q06uKs2CkNYVID0VqwfAl9mipo99zkBv/n2JtWY89Yxa3ZabWSrs0e2KTudKVa3peLUvYXMefDqIleLPVUBZMA==
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.4.1.tgz#befd3b1195ba052f9fd2fde8a486c4e82ee77f61"
+  integrity sha512-EQyfIuO2hPDsX1L/blblV+H7I0knhgAd82cVneCwcdND9B8AuCDuRcBH6yIcG4dFzlOUqbazQqwGjx5xmsNLuQ==
   dependencies:
     kleur "^3.0.3"
-    sisteransi "^1.0.4"
+    sisteransi "^1.0.5"
 
 psl@^1.1.28:
   version "1.8.0"
@@ -3185,28 +3262,28 @@ remove-trailing-separator@^1.0.1:
   integrity sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
 
 repeat-element@^1.1.2:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.3.tgz#782e0d825c0c5a3bb39731f84efee6b742e6b1ce"
-  integrity sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/repeat-element/-/repeat-element-1.1.4.tgz#be681520847ab58c7568ac75fbfad28ed42d39e9"
+  integrity sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==
 
 repeat-string@^1.6.1:
   version "1.6.1"
   resolved "https://registry.yarnpkg.com/repeat-string/-/repeat-string-1.6.1.tgz#8dcae470e1c88abc2d600fff4a776286da75e637"
   integrity sha1-jcrkcOHIirwtYA//Sndihtp15jc=
 
-request-promise-core@1.1.3:
-  version "1.1.3"
-  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.3.tgz#e9a3c081b51380dfea677336061fea879a829ee9"
-  integrity sha512-QIs2+ArIGQVp5ZYbWD5ZLCY29D5CfWizP8eWnm8FoGD1TX61veauETVQbrV60662V0oFBkrDOuaBI8XgtuyYAQ==
+request-promise-core@1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/request-promise-core/-/request-promise-core-1.1.4.tgz#3eedd4223208d419867b78ce815167d10593a22f"
+  integrity sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
   dependencies:
-    lodash "^4.17.15"
+    lodash "^4.17.19"
 
 request-promise-native@^1.0.5:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.8.tgz#a455b960b826e44e2bf8999af64dff2bfe58cb36"
-  integrity sha512-dapwLGqkHtwL5AEbfenuzjTYg35Jd6KPytsC2/TLkVMz8rm+tNt72MGUWT1RP/aYawMpN6HqbNGBQaRcBtjQMQ==
+  version "1.0.9"
+  resolved "https://registry.yarnpkg.com/request-promise-native/-/request-promise-native-1.0.9.tgz#e407120526a5efdc9a39b28a5679bf47b9d9dc28"
+  integrity sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
   dependencies:
-    request-promise-core "1.1.3"
+    request-promise-core "1.1.4"
     stealthy-require "^1.1.1"
     tough-cookie "^2.3.3"
 
@@ -3280,11 +3357,12 @@ resolve@1.1.7:
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.1.7.tgz#203114d82ad2c5ed9e8e0411b3932875e889e97b"
   integrity sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=
 
-resolve@^1.10.0, resolve@^1.3.2:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.17.0.tgz#b25941b54968231cc2d1bb76a79cb7f2c0bf8444"
-  integrity sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==
+resolve@^1.10.0:
+  version "1.20.0"
+  resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.20.0.tgz#629a013fb3f70755d6f0b7935cc1c2c5378b1975"
+  integrity sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==
   dependencies:
+    is-core-module "^2.2.0"
     path-parse "^1.0.6"
 
 restore-cursor@^3.1.0:
@@ -3327,18 +3405,9 @@ rsvp@^4.8.4:
   integrity sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
 
 run-async@^2.4.0:
-  version "2.4.0"
-  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.0.tgz#e59054a5b86876cfae07f431d18cbaddc594f1e8"
-  integrity sha512-xJTbh/d7Lm7SBhc1tNvTpeCHaEzoyxPrqNlvSdMfBTYwaY++UJFyXUOxAtsRUXjlqOfj8luNaR9vjCh4KeV+pg==
-  dependencies:
-    is-promise "^2.1.0"
-
-rxjs@^6.5.3:
-  version "6.5.5"
-  resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.5.5.tgz#c5c884e3094c8cfee31bf27eb87e54ccfc87f9ec"
-  integrity sha512-WfQI+1gohdf0Dai/Bbmk5L5ItH5tYqm3ki2c5GdWhKjalzjg93N3avFjVStyZZz+A2Em+ZxKH5bNghw9UeylGQ==
-  dependencies:
-    tslib "^1.9.0"
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/run-async/-/run-async-2.4.1.tgz#8440eccf99ea3e70bd409d49aab88e10c189a455"
+  integrity sha512-tvVnVv01b8c1RrA6Ep7JkStj85Guv/YrMcwqYQnwjsAS2cTmmPGBBjAjpCW7RrSodNSoE2/qg9O4bceNvUuDgQ==
 
 rxjs@^6.6.0:
   version "6.6.7"
@@ -3348,9 +3417,9 @@ rxjs@^6.6.0:
     tslib "^1.9.0"
 
 safe-buffer@^5.0.1, safe-buffer@^5.1.2:
-  version "5.2.0"
-  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.0.tgz#b74daec49b1148f88c64b68d49b1e815c1f2f519"
-  integrity sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==
+  version "5.2.1"
+  resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
+  integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
 
 safe-buffer@~5.1.1:
   version "5.1.2"
@@ -3389,12 +3458,12 @@ sax@^1.2.4:
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.4.tgz#2816234e2378bddc4e5354fab5caa895df7100d9"
   integrity sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==
 
-"semver@2 || 3 || 4 || 5", semver@^5.4.1, semver@^5.5.0, semver@^5.6.0:
+"semver@2 || 3 || 4 || 5", semver@^5.5.0, semver@^5.6.0:
   version "5.7.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.7.1.tgz#a954f931aeba508d307bbf069eff0c01c96116f7"
   integrity sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
 
-semver@^6.0.0, semver@^6.1.2, semver@^6.2.0:
+semver@^6.0.0, semver@^6.1.2, semver@^6.2.0, semver@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.0.tgz#ee0a64c8af5e8ceea67687b133761e1becbd1d3d"
   integrity sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
@@ -3443,7 +3512,7 @@ signal-exit@^3.0.0, signal-exit@^3.0.2:
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.3.tgz#a1410c2edd8f077b08b4e253c8eacfcaf057461c"
   integrity sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
 
-sisteransi@^1.0.4:
+sisteransi@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/sisteransi/-/sisteransi-1.0.5.tgz#134d681297756437cc05ca01370d3a7a571075ed"
   integrity sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
@@ -3504,17 +3573,17 @@ source-map-resolve@^0.5.0:
     urix "^0.1.0"
 
 source-map-support@^0.5.6:
-  version "0.5.18"
-  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.18.tgz#f5f33489e270bd7f7d7e7b8debf283f3a4066960"
-  integrity sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==
+  version "0.5.19"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.19.tgz#a98b62f86dcaf4f67399648c085291ab9e8fed61"
+  integrity sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
   dependencies:
     buffer-from "^1.0.0"
     source-map "^0.6.0"
 
 source-map-url@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.0.tgz#3e935d7ddd73631b97659956d55128e87b5084a3"
-  integrity sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
+  version "0.4.1"
+  resolved "https://registry.yarnpkg.com/source-map-url/-/source-map-url-0.4.1.tgz#0af66605a745a5a2f91cf1bbf8a7afbc283dec56"
+  integrity sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==
 
 source-map@^0.5.0, source-map@^0.5.6:
   version "0.5.7"
@@ -3527,9 +3596,9 @@ source-map@^0.6.0, source-map@^0.6.1, source-map@~0.6.1:
   integrity sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
 
 spdx-correct@^3.0.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.0.tgz#fb83e504445268f154b074e218c87c003cd31df4"
-  integrity sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/spdx-correct/-/spdx-correct-3.1.1.tgz#dece81ac9c1e6713e5f7d1b6f17d468fa53d89a9"
+  integrity sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==
   dependencies:
     spdx-expression-parse "^3.0.0"
     spdx-license-ids "^3.0.0"
@@ -3540,17 +3609,17 @@ spdx-exceptions@^2.1.0:
   integrity sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
 
 spdx-expression-parse@^3.0.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz#99e119b7a5da00e05491c9fa338b7904823b41d0"
-  integrity sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz#cf70f50482eefdc98e3ce0a6833e4a53ceeba679"
+  integrity sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
   dependencies:
     spdx-exceptions "^2.1.0"
     spdx-license-ids "^3.0.0"
 
 spdx-license-ids@^3.0.0:
-  version "3.0.5"
-  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz#3694b5804567a458d3c8045842a6358632f62654"
-  integrity sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==
+  version "3.0.9"
+  resolved "https://registry.yarnpkg.com/spdx-license-ids/-/spdx-license-ids-3.0.9.tgz#8a595135def9592bda69709474f1cbeea7c2467f"
+  integrity sha512-Ki212dKK4ogX+xDo4CtOZBVIwhsKBEfsEEcwmJfLQzirgc2jIWdzg40Unxz/HzEUqM1WFzVlQSMF9kZZ2HboLQ==
 
 split-string@^3.0.1, split-string@^3.0.2:
   version "3.1.0"
@@ -3580,9 +3649,11 @@ sshpk@^1.7.0:
     tweetnacl "~0.14.0"
 
 stack-utils@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.2.tgz#33eba3897788558bebfc2db059dc158ec36cebb8"
-  integrity sha512-MTX+MeG5U994cazkjd/9KNAapsHnibjMLnfXodlkXw76JEea0UiNzrqidzo1emMwk7w5Qhc9jd4Bn9TBb1MFwA==
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/stack-utils/-/stack-utils-1.0.5.tgz#a19b0b01947e0029c8e451d5d61a498f5bb1471b"
+  integrity sha512-KZiTzuV3CnSnSvgMRrARVCj+Ht7rMbauGDK0LdVFRGyenwdylpajAp4Q0i6SX8rEmbTpMMf6ryq2gb8pPq2WgQ==
+  dependencies:
+    escape-string-regexp "^2.0.0"
 
 static-extend@^0.1.1:
   version "0.1.2"
@@ -3615,47 +3686,29 @@ string-width@^3.0.0, string-width@^3.1.0:
     strip-ansi "^5.1.0"
 
 string-width@^4.1.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.0.tgz#952182c46cc7b2c313d1596e623992bd163b72b5"
-  integrity sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+  version "4.2.2"
+  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.2.tgz#dafd4f9559a7585cfba529c6a0a4f73488ebd4c5"
+  integrity sha512-XBJbT3N4JhVumXE0eoLU9DCjcaF92KLNqTmFCnG1pf8duUxFGwtP6AD6nkjw9a3IdiRtL3E2w3JDiE/xi3vOeA==
   dependencies:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string.prototype.trimend@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz#85812a6b847ac002270f5808146064c995fb6913"
-  integrity sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==
+string.prototype.trimend@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.4.tgz#e75ae90c2942c63504686c18b287b4a0b1a45f80"
+  integrity sha512-y9xCjw1P23Awk8EvTpcyL2NIr1j7wJ39f+k6lvRnSMz+mz9CGz9NYPelDk42kOz6+ql8xjfK8oYzy3jAP5QU5A==
   dependencies:
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.17.5"
 
-string.prototype.trimleft@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz#4408aa2e5d6ddd0c9a80739b087fbc067c03b3cc"
-  integrity sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==
+string.prototype.trimstart@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.4.tgz#b36399af4ab2999b4c9c648bd7a3fb2bb26feeed"
+  integrity sha512-jh6e984OBfvxS50tdY2nRZnoC5/mLFKOREQfw8t5yytkoUsJRNxvI/E39qu1sD0OtWI3OC0XgKSmcWwziwYuZw==
   dependencies:
+    call-bind "^1.0.2"
     define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-    string.prototype.trimstart "^1.0.0"
-
-string.prototype.trimright@^2.1.1:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz#c76f1cef30f21bbad8afeb8db1511496cfb0f2a3"
-  integrity sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
-    string.prototype.trimend "^1.0.0"
-
-string.prototype.trimstart@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz#14af6d9f34b053f7cfc89b72f8f2ee14b9039a54"
-  integrity sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.17.5"
 
 strip-ansi@^4.0.0:
   version "4.0.0"
@@ -3689,9 +3742,9 @@ strip-eof@^1.0.0:
   integrity sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
 
 strip-json-comments@^3.0.1, strip-json-comments@^3.1.0:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.0.tgz#7638d31422129ecf4457440009fba03f9f9ac180"
-  integrity sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w==
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.1.1.tgz#31f1281b3832630434831c310c01cccda8cbe006"
+  integrity sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
 
 supports-color@^5.3.0:
   version "5.5.0"
@@ -3708,9 +3761,9 @@ supports-color@^6.1.0:
     has-flag "^3.0.0"
 
 supports-color@^7.1.0:
-  version "7.1.0"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.1.0.tgz#68e32591df73e25ad1c4b49108a2ec507962bfd1"
-  integrity sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==
+  version "7.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-7.2.0.tgz#1b7dcdcb32b8138801b3e478ba6a51caa89648da"
+  integrity sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
   dependencies:
     has-flag "^4.0.0"
 
@@ -3837,9 +3890,9 @@ ts-typed-json@^0.3.2:
   integrity sha512-Tdu3BWzaer7R5RvBIJcg9r8HrTZgpJmsX+1meXMJzYypbkj8NK2oJN0yvm4Dp/Iv6tzFa/L5jKRmEVTga6K3nA==
 
 tslib@^1.9.0:
-  version "1.11.1"
-  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.11.1.tgz#eb15d128827fbee2841549e171f45ed338ac7e35"
-  integrity sha512-aZW88SY8kQbU7gpV19lN24LtXh/yD4ZZg6qieAJDDg+YBsJcSmLGK9QpnUjAKVG/xefmvJGd1WUmfpT/g6AJGA==
+  version "1.14.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
+  integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
 tunnel-agent@^0.6.0:
   version "0.6.0"
@@ -3860,10 +3913,10 @@ type-check@~0.3.2:
   dependencies:
     prelude-ls "~1.1.2"
 
-type-fest@^0.11.0:
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.11.0.tgz#97abf0872310fed88a5c466b25681576145e33f1"
-  integrity sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+type-fest@^0.21.3:
+  version "0.21.3"
+  resolved "https://registry.yarnpkg.com/type-fest/-/type-fest-0.21.3.tgz#d260a24b0198436e133fa26a524a6d65fa3b2e37"
+  integrity sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==
 
 type-fest@^0.8.1:
   version "0.8.1"
@@ -3886,16 +3939,24 @@ uc.micro@^1.0.1, uc.micro@^1.0.5:
   integrity sha512-8Y75pvTYkLJW2hWQHXxoqRgV7qb9B+9vFEtidML+7koHUFapnVJAZ6cKs+Qjz5Aw3aZWHMC6u0wJE3At+nSGwA==
 
 uglify-js@^3.1.4:
-  version "3.9.1"
-  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.9.1.tgz#a56a71c8caa2d36b5556cc1fd57df01ae3491539"
-  integrity sha512-JUPoL1jHsc9fOjVFHdQIhqEEJsQvfKDjlubcCilu8U26uZ73qOg8VsN8O1jbuei44ZPlwL7kmbAdM4tzaUvqnA==
-  dependencies:
-    commander "~2.20.3"
+  version "3.13.10"
+  resolved "https://registry.yarnpkg.com/uglify-js/-/uglify-js-3.13.10.tgz#a6bd0d28d38f592c3adb6b180ea6e07e1e540a8d"
+  integrity sha512-57H3ACYFXeo1IaZ1w02sfA71wI60MGco/IQFjOqK+WtKoprh7Go2/yvd2HPtoJILO2Or84ncLccI4xoHMTSbGg==
 
-underscore@~1.10.2:
-  version "1.10.2"
-  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.10.2.tgz#73d6aa3668f3188e4adb0f1943bd12cfd7efaaaf"
-  integrity sha512-N4P+Q/BuyuEKFJ43B9gYuOj4TQUHXX+j2FqguVOpjkssLUUrnJofCcBccJSCoeturDoZU6GorDTHSvUDlSQbTg==
+unbox-primitive@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/unbox-primitive/-/unbox-primitive-1.0.1.tgz#085e215625ec3162574dc8859abee78a59b14471"
+  integrity sha512-tZU/3NqK3dA5gpE1KtyiJUrEB0lxnGkMFHptJ7q6ewdZ8s12QrODwNbhIJStmJkd1QDXa1NRA8aF2A1zk/Ypyw==
+  dependencies:
+    function-bind "^1.1.1"
+    has-bigints "^1.0.1"
+    has-symbols "^1.0.2"
+    which-boxed-primitive "^1.0.2"
+
+underscore@~1.13.1:
+  version "1.13.1"
+  resolved "https://registry.yarnpkg.com/underscore/-/underscore-1.13.1.tgz#0c1c6bd2df54b6b69f2314066d65b6cde6fcf9d1"
+  integrity sha512-hzSoAVtJF+3ZtiFX0VgfFPHEDRm7Y/QPjGyNo4TVdnDTdft3tr8hEkD25a1jC+TjTuE7tkHGKkhwCgs9dgBB2g==
 
 union-value@^1.0.0:
   version "1.0.1"
@@ -3916,9 +3977,9 @@ unset-value@^1.0.0:
     isobject "^3.0.0"
 
 uri-js@^4.2.2:
-  version "4.2.2"
-  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.2.2.tgz#94c540e1ff772956e2299507c010aea6c8838eb0"
-  integrity sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==
+  version "4.4.1"
+  resolved "https://registry.yarnpkg.com/uri-js/-/uri-js-4.4.1.tgz#9b1a52595225859e55f669d928f88c6c57f2a77e"
+  integrity sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
   dependencies:
     punycode "^2.1.0"
 
@@ -3933,14 +3994,15 @@ use@^3.1.0:
   integrity sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
 
 util.promisify@^1.0.0:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.0.1.tgz#6baf7774b80eeb0f7520d8b81d07982a59abbaee"
-  integrity sha512-g9JpC/3He3bm38zsLupWryXHoEcS22YHthuPQSJdMy6KNrzIRzWqcsHzD/WUnqe45whVou4VIsPew37DoXWNrA==
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/util.promisify/-/util.promisify-1.1.1.tgz#77832f57ced2c9478174149cae9b96e9918cd54b"
+  integrity sha512-/s3UsZUrIfa6xDhr7zZhnE9SLQ5RIXyYfiVnMMyMDzOc8WhWN4Nbh36H842OyurKbCDAesZOJaVyvmSl6fhGQw==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.17.2"
+    for-each "^0.3.3"
     has-symbols "^1.0.1"
-    object.getownpropertydescriptors "^2.1.0"
+    object.getownpropertydescriptors "^2.1.1"
 
 uuid@^3.3.2:
   version "3.4.0"
@@ -3948,9 +4010,9 @@ uuid@^3.3.2:
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
 v8-compile-cache@^2.0.3:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz#e14de37b31a6d194f5690d67efc4e7f6fc6ab30e"
-  integrity sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==
+  version "2.3.0"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
+  integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
 
 validate-npm-package-license@^3.0.1, validate-npm-package-license@^3.0.4:
   version "3.0.4"
@@ -4025,6 +4087,17 @@ whatwg-url@^7.0.0:
     tr46 "^1.0.1"
     webidl-conversions "^4.0.2"
 
+which-boxed-primitive@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/which-boxed-primitive/-/which-boxed-primitive-1.0.2.tgz#13757bc89b209b049fe5d86430e21cf40a89a8e6"
+  integrity sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==
+  dependencies:
+    is-bigint "^1.0.1"
+    is-boolean-object "^1.1.0"
+    is-number-object "^1.0.4"
+    is-string "^1.0.5"
+    is-symbol "^1.0.3"
+
 which-module@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/which-module/-/which-module-2.0.0.tgz#d9ef07dce77b9902b8a3a8fa4b31c3e3f7e6e87a"
@@ -4086,9 +4159,9 @@ write@1.0.3:
     mkdirp "^0.5.1"
 
 ws@^5.2.0:
-  version "5.2.2"
-  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.2.tgz#dffef14866b8e8dc9133582514d1befaf96e980f"
-  integrity sha512-jaHFD6PFv6UgoIVda6qZllptQsMlDEJkTQcybzzXDYM1XO9Y8em691FGMPmM46WGyLU4z9KMgQN+qrux/nhlHA==
+  version "5.2.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-5.2.3.tgz#05541053414921bc29c63bee14b8b0dd50b07b3d"
+  integrity sha512-jZArVERrMsKUatIdnLzqvcfydI85dvd/Fp1u/VOpfdDWQ4c9qWXe+VIeAbQ5FrDwciAkr+lzofXLz3Kuf26AOA==
   dependencies:
     async-limiter "~1.0.0"
 
@@ -4103,9 +4176,9 @@ xmlcreate@^2.0.3:
   integrity sha512-HgS+X6zAztGa9zIK3Y3LXuJes33Lz9x+YyTxgrkIdabu2vqcGOWwdfCpf1hWLRrd553wd4QCDf6BBO6FfdsRiQ==
 
 y18n@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.1.tgz#8db2b83c31c5d75099bb890b23f3094891e247d4"
-  integrity sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/y18n/-/y18n-4.0.3.tgz#b5f259c82cd6e336921efd7bfd8bf560de9eeedf"
+  integrity sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==
 
 yallist@^4.0.0:
   version "4.0.0"

--- a/src/database/recovery.rs
+++ b/src/database/recovery.rs
@@ -458,7 +458,7 @@ pub(crate) mod test {
         let (version, reindex_needed) = Database::get_version(&mut connection).unwrap();
 
         assert_eq!(version, DATABASE_VERSION);
-        assert_eq!(reindex_needed, false);
+        assert!(!reindex_needed);
 
         let result = db.search("Hello", &SearchConfig::new()).unwrap().results;
         assert!(!result.is_empty())


### PR DESCRIPTION
This is a continuation of https://github.com/matrix-org/seshat/pull/95.

It mainly switches to spawning a thread per task instead of using a single thread that waits for tasks on an mpsc channel. The single-thread way of doing things produced some dangling objects and jest would complain about them.

The JS wrapper has also been cleaned up a bit and the exported methods from the Rust side use camel case now.

One thing to mention is, the situation with neon-serde seems to be sad, upstream is unresponsive and it seems that we'll have to start packaging it ourselves.

