### PR TITLE
seshat-node: Switch to our released fork of neon-serde

### DIFF
--- a/seshat-node/native/Cargo.lock
+++ b/seshat-node/native/Cargo.lock
@@ -1013,9 +1013,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "neon-serde"
-version = "0.4.0"
-source = "git+https://github.com/matrix-org/neon-serde?rev=ee44a7e465e8082f7d7e5a7fe2980188930a50cf#ee44a7e465e8082f7d7e5a7fe2980188930a50cf"
+name = "neon-serde2"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45f71398df9759a24867086aac5dd7ae523c91757815c27f376126d9c9d37a73"
 dependencies = [
  "error-chain",
  "neon",
@@ -1067,9 +1068,9 @@ dependencies = [
 
 [[package]]
 name = "num"
-version = "0.2.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8536030f9fea7127f841b45bb6243b27255787fb4eb83958aa1ef9d2fdc0c36"
+checksum = "43db66d1170d347f9a065114077f7dccb00c1b9478c89384490a3425279a4606"
 dependencies = [
  "num-complex",
  "num-integer",
@@ -1080,11 +1081,10 @@ dependencies = [
 
 [[package]]
 name = "num-complex"
-version = "0.2.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6b19411a9719e753aff12e5187b74d60d3dc449ec3f4dc21e3989c3f554bc95"
+checksum = "26873667bbbb7c5182d4a37c1add32cdf09f841af72da53318fdb81543c15085"
 dependencies = [
- "autocfg 1.0.1",
  "num-traits",
 ]
 
@@ -1111,9 +1111,9 @@ dependencies = [
 
 [[package]]
 name = "num-rational"
-version = "0.2.4"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c000134b5dbf44adc5cb772486d335293351644b801551abe8f75c84cfa4aef"
+checksum = "d41702bd167c2df5520b384281bc111a4b5efcf7fbc4c9c222c815b07e0a6a6a"
 dependencies = [
  "autocfg 1.0.1",
  "num-integer",
@@ -1706,7 +1706,7 @@ version = "2.2.4"
 dependencies = [
  "fs_extra",
  "neon",
- "neon-serde",
+ "neon-serde2",
  "serde_json",
  "seshat",
  "uuid",

--- a/seshat-node/native/Cargo.toml
+++ b/seshat-node/native/Cargo.toml
@@ -16,7 +16,7 @@ crate-type = ["cdylib"]
 [dependencies]
 fs_extra = "1.2.0"
 serde_json = "1.0.58"
-neon-serde = { git = "https://github.com/matrix-org/neon-serde", rev = "ee44a7e465e8082f7d7e5a7fe2980188930a50cf" }
+neon-serde2 = "0.8"
 uuid = "0.8.1"
 seshat = { version = "2.2.4", path = "../../" }
 

--- a/seshat-node/native/src/utils.rs
+++ b/seshat-node/native/src/utils.rs
@@ -224,7 +224,7 @@ pub(crate) fn deserialize_event<'a, C: Context<'a>>(
         }
     };
 
-    let ret = match neon_serde::to_value(&mut *cx, &source) {
+    let ret = match neon_serde2::to_value(&mut *cx, &source) {
         Ok(v) => v,
         Err(e) => return cx.throw_error::<_, _>(e.to_string()),
     };
@@ -253,7 +253,7 @@ pub(crate) fn search_result_to_js<'a, C: Context<'a>>(
             Ok(e) => e,
             Err(_) => continue,
         };
-        let js_event = match neon_serde::to_value(&mut *cx, &js_event) {
+        let js_event = match neon_serde2::to_value(&mut *cx, &js_event) {
             Ok(v) => v,
             Err(e) => return cx.throw_error::<_, _>(e.to_string()),
         };
@@ -266,7 +266,7 @@ pub(crate) fn search_result_to_js<'a, C: Context<'a>>(
             Ok(e) => e,
             Err(_) => continue,
         };
-        let js_event = match neon_serde::to_value(&mut *cx, &js_event) {
+        let js_event = match neon_serde2::to_value(&mut *cx, &js_event) {
             Ok(v) => v,
             Err(e) => return cx.throw_error::<_, _>(e.to_string()),
         };
@@ -411,7 +411,7 @@ pub(crate) fn parse_event(
     };
 
     let event_value = event.as_value(&mut *cx);
-    let event_source: serde_json::Value = match neon_serde::from_value(&mut *cx, event_value) {
+    let event_source: serde_json::Value = match neon_serde2::from_value(&mut *cx, event_value) {
         Ok(v) => v,
         Err(e) => return cx.throw_error::<_, _>(e.to_string()),
     };


### PR DESCRIPTION
This PR switches out to our own release of neon-serde since upstream seems to be unresponsive and practically dead.

This is needed because we bumped our neon version due to the latest Electron requiring a fresher neon release and neon-serde needs to track the neon version.