### PR TITLE
Fix quote search when passing a room_id

### DIFF
--- a/src/database/mod.rs
+++ b/src/database/mod.rs
@@ -132,7 +132,7 @@ impl Database {
             return Err(Error::ReindexError);
         }
 
-        let index = Database::create_index(&path, &config)?;
+        let index = Database::create_index(&path, config)?;
         let writer = index.get_writer()?;
 
         // Warning: Do not open a new db connection before we write the tables
@@ -180,7 +180,7 @@ impl Database {
     pub fn change_passphrase(self, new_passphrase: &str) -> Result<()> {
         match &self.config.passphrase {
             Some(p) => {
-                Index::change_passphrase(&self.path, &p, new_passphrase)?;
+                Index::change_passphrase(&self.path, p, new_passphrase)?;
                 self.connection.lock().unwrap().pragma_update(
                     None,
                     "rekey",
@@ -243,7 +243,7 @@ impl Database {
     }
 
     fn create_index<P: AsRef<Path>>(path: &P, config: &Config) -> Result<Index> {
-        Ok(Index::new(path, &config)?)
+        Ok(Index::new(path, config)?)
     }
 
     fn spawn_writer(

--- a/src/database/recovery.rs
+++ b/src/database/recovery.rs
@@ -223,7 +223,7 @@ impl RecoveryDatabase {
                 IoError::new(ErrorKind::Other, "Server timestamp out of valid range")
             })?,
             room_id,
-            &event_source,
+            event_source,
         ))
     }
 

--- a/src/database/static_methods.rs
+++ b/src/database/static_methods.rs
@@ -157,8 +157,7 @@ impl Database {
         let (new_checkpoint, old_checkpoint, events) = message;
         let transaction = connection.transaction()?;
 
-        let (ret, event_ids) =
-            Database::write_events_helper(&transaction, index_writer, events)?;
+        let (ret, event_ids) = Database::write_events_helper(&transaction, index_writer, events)?;
         Database::replace_crawler_checkpoint(
             &transaction,
             new_checkpoint.as_ref(),
@@ -900,7 +899,7 @@ impl Database {
         }
 
         let event_num = search_result.len();
-        let parameter_str = ", ?".repeat(event_num - 1);            
+        let parameter_str = ", ?".repeat(event_num - 1);
 
         let mut stmt = if order_by_recency {
             connection.prepare(&format!(

--- a/src/database/writer.rs
+++ b/src/database/writer.rs
@@ -117,7 +117,7 @@ impl Writer {
         let ret = Database::load_pending_deletion_events(&self.connection)?;
 
         for event_id in &ret {
-            self.inner.delete_event(&event_id);
+            self.inner.delete_event(event_id);
         }
 
         self.pending_deletion_events.extend(ret);

--- a/src/index/encrypted_dir.rs
+++ b/src/index/encrypted_dir.rs
@@ -16,7 +16,7 @@ use rand::{thread_rng, Rng};
 use std::{
     fs::File,
     io::{BufWriter, Cursor, Error as IoError, ErrorKind, Read, Write},
-    path::{Path}
+    path::Path,
 };
 
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
@@ -151,7 +151,7 @@ pub(crate) const PBKDF_COUNT: u32 = 10_000;
 /// [pbkdf]: https://en.wikipedia.org/wiki/PBKDF2
 /// [hkdf]: https://en.wikipedia.org/wiki/HKDF
 /// [hmac]: https://en.wikipedia.org/wiki/HMAC
-pub struct EncryptedMmapDirectory {    
+pub struct EncryptedMmapDirectory {
     mmap_dir: tantivy::directory::MmapDirectory,
     encryption_key: KeyBuffer,
     mac_key: KeyBuffer,
@@ -165,7 +165,7 @@ impl EncryptedMmapDirectory {
         // Open our underlying bare Tantivy mmap based directory.
         let mmap_dir = tantivy::directory::MmapDirectory::open(&path)?;
 
-        Ok(EncryptedMmapDirectory {            
+        Ok(EncryptedMmapDirectory {
             mmap_dir,
             encryption_key,
             mac_key,
@@ -504,12 +504,7 @@ impl EncryptedMmapDirectory {
     fn rederive_key(passphrase: &str, salt: &[u8], pbkdf_count: u32) -> KeyDerivationResult {
         let mut pbkdf_result = Zeroizing::new([0u8; KEY_SIZE * 2]);
 
-        pbkdf2::<Hmac<Sha512>>(
-            passphrase.as_bytes(),
-            salt,
-            pbkdf_count,
-            &mut *pbkdf_result,
-        );
+        pbkdf2::<Hmac<Sha512>>(passphrase.as_bytes(), salt, pbkdf_count, &mut *pbkdf_result);
         let (key, hmac_key) = pbkdf_result.split_at(KEY_SIZE);
         (
             Zeroizing::new(Vec::from(key)),

--- a/src/index/encrypted_stream.rs
+++ b/src/index/encrypted_stream.rs
@@ -258,7 +258,7 @@ impl<D: NewStreamCipher + SyncStreamCipher + SyncStreamCipherSeek, R: Read + See
 
         reader.seek(SeekFrom::Start(u_iv_length))?;
 
-        let dec = D::new_var(&key, &iv).map_err(|e| {
+        let dec = D::new_var(key, &iv).map_err(|e| {
             Error::new(
                 ErrorKind::Other,
                 format!("Invalid key or iv length: {}", e.to_string()),
@@ -378,7 +378,7 @@ fn enc_unaligned() {
         let mut aes =
             AesWriter::<Aes128Ctr, Hmac<Sha256>, _>::new(&mut enc, &key, &hmac_key, 16).unwrap();
         for chunk in orig.chunks(3) {
-            aes.write_all(&chunk).unwrap();
+            aes.write_all(chunk).unwrap();
         }
     }
     let dec = decrypt(Cursor::new(&enc));

--- a/src/index/encrypted_stream.rs
+++ b/src/index/encrypted_stream.rs
@@ -353,7 +353,7 @@ fn encrypt(data: &[u8]) -> Vec<u8> {
     {
         let mut aes =
             AesWriter::<Aes128Ctr, Hmac<Sha256>, _>::new(&mut enc, &key, &hmac_key, 16).unwrap();
-        aes.write_all(&data).unwrap();
+        aes.write_all(data).unwrap();
     }
     enc
 }

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -206,7 +206,7 @@ impl IndexSearcher {
 
         let term = if let Some(room) = &config.room_id {
             keys.push(self.room_id_field);
-            format!("+room_id:\"{}\" AND \"{}\"", room, term)
+            format!("+room_id:\"{}\" AND {}", room, term)
         } else if term.is_empty() {
             "*".to_owned()
         } else {

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -579,7 +579,7 @@ fn add_events_to_differing_rooms() {
 
     let searcher = index.get_searcher();
     let result = searcher
-        .search("Test", &SearchConfig::new().for_room(&EVENT.room_id))
+        .search("Test", SearchConfig::new().for_room(&EVENT.room_id))
         .unwrap()
         .results;
 

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -171,7 +171,7 @@ impl Writer {
 
     /// Delete the event with the given event id from the index.
     pub fn delete_event(&mut self, event_id: &str) {
-        let term = Term::from_field_text(self.event_id_field, &event_id);
+        let term = Term::from_field_text(self.event_id_field, event_id);
         self.inner.delete_term(term);
         self.inner.commit().unwrap();
     }
@@ -307,7 +307,7 @@ impl IndexSearcher {
                     og_limit,
                     limit + SEARCH_LIMIT_INCREMENT,
                     order_by_recency,
-                    &previous_results,
+                    previous_results,
                     query,
                 )
             }
@@ -323,7 +323,7 @@ impl IndexSearcher {
     ) -> Result<SearchResult, tv::TantivyError> {
         let past_search = if let Some(token) = &config.next_batch {
             let mut search_cache = self.search_cache.write().unwrap();
-            search_cache.get_mut(&token).cloned()
+            search_cache.get_mut(token).cloned()
         } else {
             None
         };
@@ -451,7 +451,7 @@ impl Index {
     ) -> tv::Result<tv::Index> {
         match &config.passphrase {
             Some(p) => {
-                let dir = EncryptedMmapDirectory::open_or_create(path, &p, PBKDF_COUNT)?;
+                let dir = EncryptedMmapDirectory::open_or_create(path, p, PBKDF_COUNT)?;
                 tv::Index::open_or_create(dir, schema)
             }
             None => {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -200,7 +200,7 @@ fn search_quoted_with_room() {
     let result = db
         .search(
             "\"Test message\"",
-            &SearchConfig::new().for_room("!test_room:localhost"),
+            SearchConfig::new().for_room("!test_room:localhost"),
         )
         .unwrap()
         .results;
@@ -316,7 +316,7 @@ fn search_with_specific_key() {
     db.reload().unwrap();
 
     let result = searcher
-        .search("Test", &SearchConfig::new().with_key(EventType::Topic))
+        .search("Test", SearchConfig::new().with_key(EventType::Topic))
         .unwrap()
         .results;
     assert!(result.is_empty());
@@ -327,7 +327,7 @@ fn search_with_specific_key() {
 
     let searcher = db.get_searcher();
     let result = searcher
-        .search("Test", &SearchConfig::new().with_key(EventType::Topic))
+        .search("Test", SearchConfig::new().with_key(EventType::Topic))
         .unwrap()
         .results;
     assert_eq!(result.len(), 1);

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -197,7 +197,13 @@ fn search_quoted_with_room() {
     db.force_commit().unwrap();
     db.reload().unwrap();
 
-    let result = db.search("\"Test message\"", &SearchConfig::new().for_room("!test_room:localhost")).unwrap().results;
+    let result = db
+        .search(
+            "\"Test message\"",
+            &SearchConfig::new().for_room("!test_room:localhost"),
+        )
+        .unwrap()
+        .results;
     assert!(!result.is_empty());
     assert_eq!(result[0].event_source, EVENT.source);
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -188,6 +188,21 @@ fn save_and_search() {
 }
 
 #[test]
+fn search_quoted_with_room() {
+    let tmpdir = tempdir().unwrap();
+    let mut db = Database::new(tmpdir.path()).unwrap();
+    let profile = Profile::new("Alice", "");
+
+    db.add_event(EVENT.clone(), profile);
+    db.force_commit().unwrap();
+    db.reload().unwrap();
+
+    let result = db.search("\"Test message\"", &SearchConfig::new().for_room("!test_room:localhost")).unwrap().results;
+    assert!(!result.is_empty());
+    assert_eq!(result[0].event_source, EVENT.source);
+}
+
+#[test]
 fn duplicate_events() {
     let tmpdir = tempdir().unwrap();
     let mut db = Database::new(tmpdir.path()).unwrap();


### PR DESCRIPTION
Passing a search term "in quotes" while also passing a room_id fails with a `IndexError(InvalidArgument("Query is invalid. SyntaxError"))`

This is because to pass a room_id, we suffix the query with the room ID clause, then append `AND "<search term>"` (i.e. the search term is explicitly quoted).

This means -

* Quoting it again breaks, and Tantivy natural search operators (e.g. AND, OR, brackets) I think are being ignored
* We're always running quoted search when a room ID is passed, which is unexpected - I think users would expect an ANDed search

So I've removed the quotes.. if that causes some other issue, maybe there's another way.