### PR TITLE
Bracket search terms

### DIFF
--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -206,7 +206,7 @@ impl IndexSearcher {
 
         let term = if let Some(room) = &config.room_id {
             keys.push(self.room_id_field);
-            format!("+room_id:\"{}\" AND {}", room, term)
+            format!("+room_id:\"{}\" AND ({})", room, term)
         } else if term.is_empty() {
             "*".to_owned()
         } else {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -205,19 +205,20 @@ fn search_with_room() {
         ("Test", true),
         ("message", true),
         ("massage", false),
-        ("\"Test massage\"", false)
+        ("\"Test massage\"", false),
     ];
 
     for (phrase, should_match) in cases.iter() {
         let result = db
-            .search(
-                phrase,
-                SearchConfig::new().for_room("!test_room:localhost"),
-            )
+            .search(phrase, SearchConfig::new().for_room("!test_room:localhost"))
             .unwrap()
-            .results;        
-        assert!(should_match == &!result.is_empty(), 
-            "searching for '{}' should not return a result, but found {}", phrase, result[0].event_source);
+            .results;
+        assert!(
+            should_match == &!result.is_empty(),
+            "searching for '{}' should not return a result, but found {}",
+            phrase,
+            result[0].event_source
+        );
         if *should_match {
             assert_eq!(result[0].event_source, EVENT.source);
         }


### PR DESCRIPTION
Without the brackets, multiple words in the query causes a syntax error.

I guess Tantivy gets confused if you provide the AND operator in some places but not others.