### PR TITLE
Add precommit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,8 @@
+repos:
+-   repo: https://github.com/doublify/pre-commit-rust
+    rev: master
+    hooks:
+    -   id: fmt
+    -   id: cargo-check
+    -   id: clippy
+        args: ["--all-targets", "--", "-D", "warnings"]

--- a/README.md
+++ b/README.md
@@ -50,3 +50,10 @@ Once events have been added a search can be done:
 ```
 let result = database.search("test", &SearchConfig::new()).unwrap();
 ```
+
+## Development
+
+Seshat uses standard cargo commands `build` and `test`.
+
+You can install [pre-commit](https://pre-commit.com/) and then `pre-commit install` 
+to ensure your work is linted on commit.


### PR DESCRIPTION
Run clippy and `cargo fmt` in precommit, similarly to CI. 