### PR TITLE
Search for any old event

### DIFF
--- a/seshat-node/index.js
+++ b/seshat-node/index.js
@@ -286,6 +286,20 @@ class Seshat {
     }
 
     /**
+     * Search the database for events older than the specified age in milliseconds.
+     * Results are sorted from oldest to newest.
+     * 
+     * @param {*} olderThan The minimum age
+     * @param {*} limit The maximum number of events that the search
+     * should return.
+
+     * @returns The array of events that were older than the specified age.
+     */
+    searchOldSync(olderThan, limit) {
+        return seshatNative.searchOldSync(this.inner, olderThan, limit);
+    }
+
+    /**
      * Search the database for events using the given search term.
      *
      * @param  {string} term The term that is used to search the database.

--- a/src/database/static_methods.rs
+++ b/src/database/static_methods.rs
@@ -660,6 +660,26 @@ impl Database {
         }
     }
 
+    pub(crate) fn load_old_events(
+        connection: &rusqlite::Connection,
+        before: u64,
+        limit: usize
+    ) -> rusqlite::Result<Vec<SerializedEvent>> {
+        let mut stmt = connection.prepare(
+            "SELECT source FROM events
+                WHERE (
+                    (server_ts <= ?1)
+                ) ORDER BY server_ts LIMIT ?2
+                ",
+        )?;
+
+        let events = stmt
+            .query_map(params![&before, &limit,], |row| {
+                row.get(0)
+            })?;
+        events.collect()
+    }
+
     pub(crate) fn load_file_events(
         connection: &rusqlite::Connection,
         room_id: &str,


### PR DESCRIPTION
I have a use case where I want to be able to easily get the set of indexed events older than a specified age.

I want to do this so I am able to delete from the index events that have been automatically deleted by the homeserver after their retention period but may remain inside the index since no redaction event is issued by the server (I think ?).

The scenario I want to avoid is if a seshat index gets fully compromised, the attacker may access the entire history, even events that expired due to room/server retention.

This PR aims to later be able to control a retention period on the client.

I will work on an async version of this next week but I am still taking feedbacks on this.
