### PR TITLE
Include the Cargo.lock file in the npm package

### DIFF
--- a/seshat-node/package.json
+++ b/seshat-node/package.json
@@ -14,6 +14,7 @@
   },
   "files": [
     "Cargo.toml",
+    "Cargo.lock",
     "src/",
     "index.js",
     "README.md"


### PR DESCRIPTION
This is needed since the Element Desktop build is quite complicated and needs to support multiple platforms.

https://github.com/matrix-org/seshat/pull/144 we set up the lockfile to target a specific OpenSSL version.

This was broken due to our switch to `pnpm` where I also configured the ignore file for packaging: 60b90edf.