### PR TITLE
Use nextest for the CI test runs

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,4 @@
+[profile.default]
+retries = { backoff = "exponential", count = 3, delay = "1s", jitter = true }
+# kill the slow tests if they still aren't up after 180s
+slow-timeout = { period = "60s", terminate-after = 3 }

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,13 +84,18 @@ jobs:
           rustup install ${{ matrix.rust || 'stable' }}
           rustup default ${{ matrix.rust || 'stable' }}
 
+      - name: Install nextest
+        uses: taiki-e/install-action@85b24a67ef0c632dfefad70b9d5ce8fddb040754 # v 2.75.10
+        with:
+          tool: nextest
+
       - name: Build Rust
         run: |
           cargo build --features=bundled-sqlcipher
 
       - name: Test Rust
         run: |
-          cargo test --features=bundled-sqlcipher
+          cargo nextest run --features=bundled-sqlcipher
 
       # Checkout again to reset the test DB state
       - name: Checkout


### PR DESCRIPTION
This allows use to automatically retry some flaky tests. We have some of those mainly due to heavily relying on writing databases in tests which might fail for IO reasons.