### PR TITLE
use hardware AES & SHA intrinsics on ARMv8

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ aes = { version = "0.8.4", optional = true }
 ctr = { version = "0.9.2", optional = true }
 crypto-mac = { version = "0.11.1", optional = true }
 hmac = { version = "0.11.0", optional = true }
-sha2 = { version = "0.9.5", optional = true }
+sha2 = { version = "0.9.5", optional = true, features = ["asm"] }
 hkdf = { version = "0.11.0", optional = true }
 pbkdf2 = { version = "0.8.0", optional = true }
 rand = { version = "0.8.5", optional = true }

--- a/README.md
+++ b/README.md
@@ -15,6 +15,16 @@ Its main use is to be used as a full text search backend for Matrix clients.
 Seshat provides JavaScript bindings which can be found in the
 [seshat-node](seshat-node) subdir.
 
+### Building the native module (with hardware crypto)
+
+```sh
+cd seshat-node
+
+# N.B. aarch64 requires you to explicitly enable hardware AES via RUSTFLAGS
+# otherwise seshat uses 10-20x more CPU than it should.
+RUSTFLAGS="--cfg aes_armv8" npm run build-bundled
+```
+
 ## Usage
 
 There are two modes of operation for Seshat, adding live events as they


### PR DESCRIPTION
The tantivy encrypted index code defaults to software AES and SHA on Apple Silicon (ARMv8) unless you explicitly pass in the right RUSTFLAGS and enable the asm feature on sha2.  This then runs 10-20x slower (aka uses 10-20x more CPU) than the hardware primitives.

Fixes bits of https://github.com/element-hq/element-web/issues/32119