### PR TITLE
ci: Enable the CI workflow on pull requests towards all branches, including main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,8 +4,9 @@ permissions: {}
 
 on:
   push:
+    branches: ["main"]
   pull_request:
-    branches: [master]
+    branches: ["**"]
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
This somewhat broke when we renamed the master branch to main.