### PR TITLE
Fix panic that could occur when deleting or editing events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+- Fix panic that could occur in the writer thread when deleting or replacing events.
+  [[#195](https://github.com/matrix-org/seshat/pull/195)]
+
 ## 4.3.0 - 2026-05-18
 
 ### Changed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,8 @@ thiserror = "1.0.26"
 tempfile = "3.2.0"
 lazy_static = "1.4.0"
 fake = "2.4.3"
+env_logger = "0.10.0"
+log = "0.4.33"
 
 [patch.crates-io]
 # Ensure that seshat-node uses the local seshat version.

--- a/src/index/mod.rs
+++ b/src/index/mod.rs
@@ -119,7 +119,10 @@ pub(crate) struct Writer {
     event_id_field: tv::schema::Field,
     sender_field: tv::schema::Field,
     date_field: tv::schema::Field,
-    added_events: usize,
+
+    /// Number of events added or deleted since the last commit
+    events_pending_commit: usize,
+
     commit_timestamp: std::time::Instant,
     room_id_field: tv::schema::Field,
 }
@@ -130,13 +133,13 @@ impl Writer {
     }
 
     fn commit_helper(&mut self, force: bool) -> Result<bool, tv::TantivyError> {
-        if self.added_events > 0
+        if self.events_pending_commit > 0
             && (force
-                || self.added_events >= COMMIT_RATE
+                || self.events_pending_commit >= COMMIT_RATE
                 || self.commit_timestamp.elapsed() >= COMMIT_TIME)
         {
             self.inner.commit()?;
-            self.added_events = 0;
+            self.events_pending_commit = 0;
             self.commit_timestamp = std::time::Instant::now();
             Ok(true)
         } else {
@@ -164,14 +167,14 @@ impl Writer {
         doc.add_u64(self.date_field, event.server_ts as u64);
 
         self.inner.add_document(doc);
-        self.added_events += 1;
+        self.events_pending_commit += 1;
     }
 
     /// Delete the event with the given event id from the index.
     pub fn delete_event(&mut self, event_id: &str) {
         let term = Term::from_field_text(self.event_id_field, event_id);
         self.inner.delete_term(term);
-        self.inner.commit().unwrap();
+        self.events_pending_commit += 1;
     }
 
     pub fn wait_merging_threads(self) -> Result<(), tv::TantivyError> {
@@ -536,7 +539,7 @@ impl Index {
             room_id_field: self.room_id_field,
             sender_field: self.sender_field,
             date_field: self.date_field,
-            added_events: 0,
+            events_pending_commit: 0,
             commit_timestamp: std::time::Instant::now(),
         })
     }
@@ -639,12 +642,12 @@ fn event_count() {
 
     let mut writer = index.get_writer().unwrap();
 
-    assert_eq!(writer.added_events, 0);
+    assert_eq!(writer.events_pending_commit, 0);
     writer.add_event(&EVENT);
-    assert_eq!(writer.added_events, 1);
+    assert_eq!(writer.events_pending_commit, 1);
 
     writer.force_commit().unwrap();
-    assert_eq!(writer.added_events, 0);
+    assert_eq!(writer.events_pending_commit, 0);
 }
 
 #[test]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -10,9 +10,16 @@ use seshat::{
 use seshat::Config;
 
 use std::path::Path;
+use std::sync::mpsc::RecvTimeoutError;
+use std::sync::{mpsc, Once};
+use std::time::Duration;
+use std::{fs, iter, thread};
 use tempfile::tempdir;
 
 use fake::{faker::internet::raw::*, locales::*, Fake};
+use log::{info, warn};
+use rand::Rng;
+use serde_json::json;
 
 pub static EVENT_SOURCE: &str = "{
     content: {
@@ -276,6 +283,147 @@ fn save_and_search_historic_events() {
     assert!(checkpoints.contains(&checkpoint));
 }
 
+fn make_random_string(length: usize) -> String {
+    const CHARSET: &[u8] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+    let mut rng = rand::thread_rng();
+    let one_char = || CHARSET[rng.gen_range(0..CHARSET.len())] as char;
+    iter::repeat_with(one_char).take(length).collect()
+}
+
+/// A test which adds some events (including replacements) to the database, and meanwhile
+/// messes with the access permissions on the database files to try to simulate Windows Defender
+/// or similar.
+///
+/// Regression test for https://github.com/matrix-org/seshat/issues/173.
+#[test]
+fn race_indexer_and_virus_scanner() {
+    init_logging();
+
+    let tmpdir = tempdir().unwrap();
+    let indexdir = tmpdir.path().to_owned();
+    let mut db = Database::new(&indexdir).unwrap();
+
+    // A thread which runs every few milliseconds, and removes write access to all the '.idx' and
+    // '.pos' files.
+    //
+    // The thread automatically exits when the test completes.
+    let (_tx, rx) = mpsc::channel::<()>();
+    thread::spawn(move || loop {
+        // Sleep for a while, but if the test thread disconnects, abort immediately and terminate
+        // the thread.
+        if let Err(RecvTimeoutError::Disconnected) = rx.recv_timeout(Duration::from_millis(50)) {
+            break;
+        }
+
+        // Find all the .pos and .idx files, and mark them as readonly.
+        for path in fs::read_dir(&indexdir)
+            .expect("unable to open index directory")
+            .map(|f| f.expect("unable to read index directory entry").path())
+            .filter(|p| {
+                p.extension()
+                    .is_some_and(|e| e.to_string_lossy() == "pos" || e.to_string_lossy() == "idx")
+            })
+        {
+            if let Err(e) = set_readonly(&path, true) {
+                // Likely the file moved under us
+                warn!(
+                    "failed to set file {} readonly: {}",
+                    path.to_string_lossy(),
+                    e
+                );
+            }
+        }
+    });
+
+    let profile = Profile::new("Alice", "");
+    let sender = format!(
+        "@{}:{}",
+        Username(EN).fake::<String>(),
+        FreeEmailProvider(EN).fake::<String>()
+    );
+
+    for cycle in 0..10 {
+        let mut events = Vec::new();
+
+        for ev in 0..10 {
+            // A unique event id, because duplicates are ignored
+            let event_id = format!("${}_{}:domain", cycle, ev);
+
+            // A reasonably unique string for the body
+            let body = make_random_string(8);
+
+            let mut event_source = json!({ "event_id": event_id });
+
+            // Some events replace earlier ones
+            if cycle > 0 && rand::random::<u8>() > 200 {
+                let original_event_id = format!("${}_{}:domain", cycle - 1, ev);
+                info!("{} replaces {}", event_id, original_event_id);
+                event_source.as_object_mut().unwrap().insert(
+                    "content".to_owned(),
+                    json!({ "m.relates_to": { "rel_type": "m.replace", "event_id": original_event_id }}),
+                );
+            }
+
+            let event = Event::new(
+                EventType::Message,
+                &body,
+                Some("m.text"),
+                &event_id,
+                &sender,
+                1516362244026,
+                &format!("!test_room_{}:localhost", cycle % 10),
+                &event_source.to_string(),
+            );
+
+            db.add_event(event.clone(), profile.clone());
+            events.push(event);
+        }
+
+        db.force_commit()
+            .unwrap_or_else(|e| warn!("Failed to commit event batch: {}", e));
+    }
+}
+
+/// Set readonly status of the given file.
+///
+/// On Windows, uses the `icacls` command to deny our user access to the files.
+#[cfg(windows)]
+fn set_readonly(path: &std::path::PathBuf, readonly: bool) -> std::io::Result<()> {
+    use std::io::ErrorKind;
+    use std::process::Command;
+
+    let user = std::env::var("USERNAME").unwrap();
+    let mut args = Vec::new();
+    args.push(path.to_str().unwrap().to_owned());
+    if readonly {
+        args.extend_from_slice(&["/deny".to_owned(), format!("{user}:(W)")])
+    } else {
+        args.extend_from_slice(&["/remove:d".to_owned(), user])
+    }
+    let status = Command::new("icacls").args(args).status()?;
+    if !status.success() {
+        return Err(std::io::Error::new(ErrorKind::Other, "icacls failed"));
+    }
+
+    Ok(())
+}
+
+/// Set readonly status of the given file.
+///
+/// On unix-like OSes, just does chmod a-w.
+#[cfg(not(windows))]
+fn set_readonly(path: &std::path::PathBuf, readonly: bool) -> std::io::Result<()> {
+    let mut perms = fs::metadata(path)?.permissions();
+
+    if perms.readonly() != readonly {
+        info!("Setting {} readonly {}", path.to_string_lossy(), readonly);
+        perms.set_readonly(readonly);
+        fs::set_permissions(path, perms)?;
+    }
+
+    Ok(())
+}
+
 #[test]
 fn get_size() {
     let tmpdir = tempdir().unwrap();
@@ -499,4 +647,11 @@ fn delete_events() {
         .results;
     assert_eq!(result.len(), 1);
     assert_eq!(result[0].event_source, TOPIC_EVENT.source);
+}
+
+fn init_logging() {
+    static INIT: Once = Once::new();
+    INIT.call_once(|| {
+        let _ = env_logger::try_init_from_env(env_logger::Env::default().default_filter_or("warn"));
+    });
 }


### PR DESCRIPTION
Remove unnecessary `commit` from `index::Writer::delete_event`.

The current call to `commit` is problematic due to the `unwrap()`, which can fail, causing the entire indexer to stop working.

Further, there's no real need to commit at this point: it's safe to wait for a later commit.

Fixes: https://github.com/matrix-org/seshat/issues/173