### PR TITLE
Fix "Collect .node files" breaking in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,11 +34,15 @@ jobs:
         uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           path: artifacts/
+          # Each artifact is named after the file it contains, so without this
+          # we'd get artifacts/foo.node/foo.node and the `find` below would
+          # match the directory rather than the file.
+          merge-multiple: true
 
       - name: Collect .node files
         run: |
           mkdir -p dist
-          find artifacts/ -name "*.node" -exec mv {} dist/ \;
+          find artifacts/ -type f -name "*.node" -exec mv -t dist/ {} +
 
       - name: Create draft GitHub Release
         run: |


### PR DESCRIPTION
Followup fix for #184 

Insufficient merging of artifacts, and insufficient specificity on the find command. 