### PR TITLE
Release 6.0.1

### DIFF
--- a/.github/workflows/publish-native.yml
+++ b/.github/workflows/publish-native.yml
@@ -41,12 +41,22 @@ jobs:
       id-token: write
 
     steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ inputs.release-tag }}
+          persist-credentials: false
+
       - name: Install Node.js
         uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
         with:
           node-version-file: ".node-version"
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false # Ignore caching for releases
+
+      # NPM trusted publishing needs npm >= 11.5.1.
+      - name: Install npm 11
+        run: npm install --global npm@11
 
       - name: Download release asset
         run: gh release download "$RELEASE_TAG" --repo "$GITHUB_REPOSITORY" --pattern "$ARTIFACT_NAME" --dir dist/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,10 @@ jobs:
           registry-url: "https://registry.npmjs.org"
           package-manager-cache: false # Ignore caching for releases
 
+      # NPM trusted publishing needs npm >= 11.5.1.
+      - name: Install npm 11
+        run: npm install --global npm@11
+
         # Pin optionalDependencies to this exact release before publishing the
         # main package, so the JS wrapper and native binaries never drift.
       - name: Publish

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## Unreleased
 
+## 6.0.1 - 2026-09-11
+
+- Fix the npm publish jobs failing to find `.node-version`.
+  [[#206](https://github.com/matrix-org/seshat/pull/206)]
+
 ## 6.0.0 - 2026-07-22
+
+*This release does not have an associated NPM/Cargo release as it was never published.*
 
 - **BREAKING**: The NPM package for the node bindings renamed from `matrix-seshat` to `@matrix-org/seshat`,
   which now includes per-platform binary packages. As a result, there is no longer a post-install script.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 members = ["seshat-node"]
 
 [workspace.package]
-version = "6.0.0"
+version = "6.0.1"
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/seshat-node/Cargo.toml
+++ b/seshat-node/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "matrix-seshat"
-version = "6.0.0"
+version = "6.0.1"
 authors = ["Damir Jelić <poljar@termina.org.uk>"]
 edition = "2018"
 license = "Apache-2.0"

--- a/seshat-node/package.json
+++ b/seshat-node/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@matrix-org/seshat",
-  "version": "6.0.0",
+  "version": "6.0.1",
   "description": "A matrix message logger with full text search support",
   "main": "index.js",
   "author": "Damir Jelić <poljar@termina.org.uk>",


### PR DESCRIPTION
Including the missing checkout step. We're going to have to burn 6.0.0 as the release pipeline failed, unfortunately.