### PR TITLE
Remove --publish-branch from release flow.

### DIFF
--- a/.github/workflows/publish-native.yml
+++ b/.github/workflows/publish-native.yml
@@ -96,4 +96,4 @@ jobs:
           PKG_CPU: ${{ inputs.pkg-cpu }}
 
       - name: Publish
-        run: npm publish --access public --provenance --publish-branch main pkg/
+        run: npm publish --access public --provenance pkg/

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -81,6 +81,6 @@ jobs:
           for pkg in linux-x64 linux-arm64 darwin-x64 darwin-arm64 win32-x64 win32-arm64; do
             npm pkg set "optionalDependencies.@matrix-org/seshat-$pkg=$RELEASE_TAG"
           done
-          npm publish --access public --provenance --publish-branch main
+          npm publish --access public --provenance
         env:
           RELEASE_TAG: ${{ github.event.release.tag_name }}


### PR DESCRIPTION
This has already been used on `6.0.1`, but it wasn't commited to main.